### PR TITLE
[Feat/#22] 내가 좋아요한 게시글 전체 조회 API 구현

### DIFF
--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -56,4 +56,11 @@ public class BoardController {
         BoardResponse boardResponse=boardService.getMyBoardDetail(memberId, boardId);
         return ResponseEntity.ok(boardResponse);
     }
+
+    @GetMapping("/member/{memberId}/board/love")
+    @Operation(summary = "내가 좋아요 한 게시글 전체 조회", description ="사용자가 좋아요 한 게시글을 모두 조회합니다.")
+    public ResponseEntity<List<BoardResponse>> getMyLovedBoards(@PathVariable Long memberId){
+        List<BoardResponse> responses=boardService.getMyLovedBoard(memberId);
+        return ResponseEntity.ok(responses);
+    }
 }

--- a/src/main/java/backend/hiteen/board/repository/BoardRepository.java
+++ b/src/main/java/backend/hiteen/board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package backend.hiteen.board.repository;
 
 import backend.hiteen.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,8 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board,Long> {
     List<Board> findAllByMemberId(Long memberId);
     Optional<Board> findByMemberIdAndId(Long memberId, Long boardId);
+
+    @Query("SELECT b FROM Board b JOIN b.loves l WHERE l.member.id=:memberId")
+    List<Board> findLikedBoardByMemberId(Long memberId);
+
 }

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -64,4 +64,11 @@ public class BoardService {
         return new BoardResponse(board);
     }
 
+    //내가 좋아요 한 게시글 전체 조회
+    @Transactional(readOnly = true)
+    public List<BoardResponse> getMyLovedBoard(Long memberId){
+        List<Board> boards=boardRepository.findLikedBoardByMemberId(memberId);
+        return boards.stream().map(BoardResponse::new).collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
# 설명
- 사용자가 자신이 좋아요한 게시글을 전체 조회하는 기능 구현

# 작업 내용
- Query문을 통해 좋아요가 되어있는 게시글 중 특정 member_id에 해당하는 게시글을 조회하도록 구현
- 사용자 인증 기능이 구현되면 memberid를 파라미터로 넘기는 대신 사용자 세션을 이용해 사용자를 인증하도록 수정 예정