### PR TITLE
[Feat/#28] 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'com.mysql:mysql-connector-j:8.3.0'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/backend/hiteen/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/backend/hiteen/board/dto/request/BoardCreateRequest.java
@@ -1,7 +1,5 @@
 package backend.hiteen.board.dto.request;
 
-import backend.hiteen.board.entity.Board;
-import backend.hiteen.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +15,6 @@ public class BoardCreateRequest {
 
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
-
 
 }
 

--- a/src/main/java/backend/hiteen/board/entity/Board.java
+++ b/src/main/java/backend/hiteen/board/entity/Board.java
@@ -34,8 +34,6 @@ public class Board extends BaseTimeEntity {
     @Column
     private int scrapCount;
 
-
-
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/backend/hiteen/config/SecurityConfig.java
+++ b/src/main/java/backend/hiteen/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package backend.hiteen.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+}
+
+

--- a/src/main/java/backend/hiteen/member/controller/MemberController.java
+++ b/src/main/java/backend/hiteen/member/controller/MemberController.java
@@ -1,4 +1,31 @@
 package backend.hiteen.member.controller;
 
+import backend.hiteen.member.dto.request.MemberCreateRequest;
+import backend.hiteen.member.dto.response.MemberResponse;
+import backend.hiteen.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@Tag(name="Member", description = "사용자 API")
 public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signUp")
+    @Operation(summary = "회원가입",description = "사용자가 회원가입을 합니다.")
+    public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody MemberCreateRequest request){
+        MemberResponse memberResponse= memberService.signUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(memberResponse);
+    }
 }

--- a/src/main/java/backend/hiteen/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/backend/hiteen/member/dto/request/MemberCreateRequest.java
@@ -1,0 +1,2 @@
+package backend.hiteen.member.dto;public class MemberCreateRequest {
+}

--- a/src/main/java/backend/hiteen/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/backend/hiteen/member/dto/request/MemberCreateRequest.java
@@ -1,2 +1,49 @@
-package backend.hiteen.member.dto;public class MemberCreateRequest {
+package backend.hiteen.member.dto.request;
+
+import backend.hiteen.member.entity.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+@NoArgsConstructor
+public class MemberCreateRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "비밀번호를 한번 더 입력해주세요.")
+    private String passwordConfirm;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+
+    @NotBlank(message = "학교를 입력해주세요.")
+    private String school;
+
+    private int gradeNumber;
+
+    private int classNumber;
+
+    public Member toEntity(PasswordEncoder encoder){
+        return Member.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .nickname(nickname)
+                .school(school)
+                .gradeNumber(gradeNumber)
+                .classNumber(classNumber)
+                .encoder(encoder)
+                .build();
+    }
 }

--- a/src/main/java/backend/hiteen/member/dto/response/MemberResponse.java
+++ b/src/main/java/backend/hiteen/member/dto/response/MemberResponse.java
@@ -1,0 +1,2 @@
+package backend.hiteen.member.dto;public class MemberResponse {
+}

--- a/src/main/java/backend/hiteen/member/dto/response/MemberResponse.java
+++ b/src/main/java/backend/hiteen/member/dto/response/MemberResponse.java
@@ -1,2 +1,25 @@
-package backend.hiteen.member.dto;public class MemberResponse {
+package backend.hiteen.member.dto.response;
+
+import backend.hiteen.member.entity.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+
+    private final String email;
+    private final String name;
+    private final String nickname;
+    private final String school;
+    private final int gradeNumber;
+    private final int classNumber;
+
+    public MemberResponse(Member member){
+        this.email=member.getEmail();
+        this.name=member.getName();
+        this.nickname=member.getNickname();
+        this.school=member.getSchool();
+        this.gradeNumber=member.getGradeNumber();
+        this.classNumber=member.getClassNumber();
+    }
+
 }

--- a/src/main/java/backend/hiteen/member/entity/Member.java
+++ b/src/main/java/backend/hiteen/member/entity/Member.java
@@ -4,22 +4,68 @@ import backend.hiteen.board.entity.Board;
 import backend.hiteen.love.entity.Love;
 import backend.hiteen.scrap.entity.Scrap;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
+import static lombok.AccessLevel.PROTECTED;
+
 @Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="member_id")
+    @Column(name = "member_id")
     private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+
+    @Embedded
+    private Password password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String school;
+
+    @Column(nullable = false)
+    private int gradeNumber;
+
+    @Column(nullable = false)
+    private int classNumber;
+
     @OneToMany(mappedBy = "member")
     private List<Board> boards;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private  List<Love> loves;
+    private List<Love> loves;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Scrap> scraps;
+
+    @Builder
+    private Member(String email, String password, String name, String nickname, String school, int gradeNumber, int classNumber, PasswordEncoder encoder) {
+        this.email = email;
+        this.password = new Password(password, encoder);
+        this.name = name;
+        this.nickname = nickname;
+        this.school = school;
+        this.classNumber = classNumber;
+        this.gradeNumber = gradeNumber;
+    }
+
+
+
 }

--- a/src/main/java/backend/hiteen/member/entity/Password.java
+++ b/src/main/java/backend/hiteen/member/entity/Password.java
@@ -1,0 +1,2 @@
+package backend.hiteen.member.entity;public class Password {
+}

--- a/src/main/java/backend/hiteen/member/entity/Password.java
+++ b/src/main/java/backend/hiteen/member/entity/Password.java
@@ -1,2 +1,35 @@
-package backend.hiteen.member.entity;public class Password {
+package backend.hiteen.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.regex.Pattern;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class Password {
+
+    private static final Pattern PASSWORD_PATTERN=Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d~`!@#$%^&*()_\\-+=]{6,}$");
+
+    @Column(name="password", nullable = false)
+    private String password;
+
+    public Password(String password, PasswordEncoder encoder){
+        validatePasswordPattern(password);
+        this.password=encoder.encode(password);
+    }
+
+    private void validatePasswordPattern(String password){
+        if (password==null || !PASSWORD_PATTERN.matcher(password).matches()){
+            throw new IllegalArgumentException("비말번호 형식이 올바르지 않습니다.");
+        }
+    }
+
+
 }

--- a/src/main/java/backend/hiteen/member/repository/MemberRepository.java
+++ b/src/main/java/backend/hiteen/member/repository/MemberRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member,Long> {
-
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickName);
 }

--- a/src/main/java/backend/hiteen/member/service/MemberService.java
+++ b/src/main/java/backend/hiteen/member/service/MemberService.java
@@ -1,4 +1,50 @@
 package backend.hiteen.member.service;
 
+import backend.hiteen.member.dto.request.MemberCreateRequest;
+import backend.hiteen.member.dto.response.MemberResponse;
+import backend.hiteen.member.entity.Member;
+import backend.hiteen.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    //회원가입
+    @Transactional
+    public MemberResponse signUp(final MemberCreateRequest request) {
+        validateDuplicateEmail(request.getEmail());
+        validateDuplicateNickname(request.getNickname());
+        validatePassword(request.getPassword(), request.getPasswordConfirm());
+        Member member=request.toEntity(passwordEncoder);
+        memberRepository.save(member);
+        return new MemberResponse(member);
+    }
+
+    //이메일 중복 예외처리
+    private void validateDuplicateEmail(String email){
+        if(memberRepository.existsByEmail(email)){
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+    }
+
+    //닉네임 중복 예외처리
+    private void validateDuplicateNickname(String nickName){
+        if(memberRepository.existsByNickname(nickName)){
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+    }
+
+    //비밀번호 확인 예외처리
+    private void validatePassword(String password, String passwordConfirm){
+        if(!password.equals(passwordConfirm)){
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+    }
 }


### PR DESCRIPTION
# 설명
- 회원가입 기능 구현

# 작업내용
- Spring Security 설정 및 로그인 리디렉션 해제
- CSRF 비활성화 및 SecurityFilterChain 설정
 
- 회원가입 구현
1. Member 엔티티 정의
2. Password 도메인 따로 분리 -> 인증 로직 구현 및 책임 분리
3. 이메일/닉네임 중복 확인 로직 구현
4. 비밀번호 확인 일치 검사 구현
5. 비밀번호 저장 시 암호화되어 저장되도록 구현

- 추후에 학교 관련 인증 기능 추가 예정