### PR TITLE
[Fix/#36] 내가 좋아요/스크랩 한 게시글 조회 api 도메인 변경

### DIFF
--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -57,17 +57,4 @@ public class BoardController {
         return ResponseEntity.ok(boardResponse);
     }
 
-    @GetMapping("/members/{memberId}/boards/loves")
-    @Operation(summary = "내가 좋아요 한 게시글 전체 조회", description ="사용자가 좋아요 한 게시글을 전체 조회합니다.")
-    public ResponseEntity<List<BoardResponse>> getMyLovedBoards(@PathVariable Long memberId){
-        List<BoardResponse> responses=boardService.getMyLovedBoard(memberId);
-        return ResponseEntity.ok(responses);
-    }
-
-    @GetMapping("members/{memberId}/boards/scraps")
-    @Operation(summary = "내가 스크랩 한 게시글 전체 조회", description ="사용자가 스크랩 한 게시글을 전체 조회합니다.")
-    public ResponseEntity<List<BoardResponse>> getMyScrapedBoards(@PathVariable Long memberId){
-        List<BoardResponse> responses=boardService.getMyScrapedBoard(memberId);
-        return ResponseEntity.ok(responses);
-    }
 }

--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -17,19 +17,19 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boards")
+@RequestMapping
 @Tag(name = "Board", description = "게시글 API")
 public class BoardController {
 
     private final BoardService boardService;
 
-    @PostMapping
+    @PostMapping("/boards")
     @Operation(summary = "게시글 추가", description = "사용자가 게시글을 작성합니다.")
     public ResponseEntity<BoardResponse> createBoard(@Valid @RequestBody BoardCreateRequest request){
         BoardResponse response=boardService.createBoard(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-    @GetMapping
+    @GetMapping("/boards")
     @Operation(summary = "게시글 전체 조회", description = "사용자가 모든 게시글을 조회합니다.")
     public ResponseEntity<List<BoardResponse>> getAllBoards(){
         List<BoardResponse> responses=boardService.getAllBoards();

--- a/src/main/java/backend/hiteen/board/repository/BoardRepository.java
+++ b/src/main/java/backend/hiteen/board/repository/BoardRepository.java
@@ -2,7 +2,6 @@ package backend.hiteen.board.repository;
 
 import backend.hiteen.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,11 +9,5 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board,Long> {
     List<Board> findAllByMemberId(Long memberId);
     Optional<Board> findByMemberIdAndId(Long memberId, Long boardId);
-
-    @Query("SELECT b FROM Board b JOIN b.loves l WHERE l.member.id=:memberId")
-    List<Board> findLikedBoardByMemberId(Long memberId);
-
-    @Query("SELECT b FROM Board b JOIN b.scraps s where s.member.id=:memberId")
-    List<Board> findScrapedBoardByMemberId(Long memberId);
 
 }

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -64,18 +64,4 @@ public class BoardService {
         return new BoardResponse(board);
     }
 
-    //내가 좋아요 한 게시글 전체 조회
-    @Transactional(readOnly = true)
-    public List<BoardResponse> getMyLovedBoard(Long memberId){
-        List<Board> boards=boardRepository.findLikedBoardByMemberId(memberId);
-        return boards.stream().map(BoardResponse::new).collect(Collectors.toList());
-    }
-
-    //내가 스크랩한 게시글 전체 조회
-    @Transactional(readOnly = true)
-    public List<BoardResponse> getMyScrapedBoard(Long memberId){
-        List<Board> boards=boardRepository.findScrapedBoardByMemberId(memberId);
-        return boards.stream().map(BoardResponse::new).collect(Collectors.toList());
-    }
-
 }

--- a/src/main/java/backend/hiteen/love/controller/LoveController.java
+++ b/src/main/java/backend/hiteen/love/controller/LoveController.java
@@ -18,14 +18,14 @@ public class LoveController {
 
     private final LoveService loveService;
 
-    @PostMapping("/members/{memberId}/boards/{boardId}/loves")
+    @PostMapping("/members/{memberId}/loves/boards/{boardId}")
     @Operation(summary = "좋아요", description = "사용자가 좋아요를 추가하거나 취소합니다.")
     public ResponseEntity<String> loveBoard(@PathVariable Long memberId, @PathVariable Long boardId){
         String message=loveService.updateLoveBoard(memberId,boardId);
         return ResponseEntity.ok(message);
     }
 
-    @GetMapping("/members/{memberId}/boards/loves")
+    @GetMapping("/members/{memberId}/loves/boards")
     @Operation(summary = "내가 좋아요 한 게시글 전체 조회", description = "사용자가 좋아요 한 게시글을 전체 조회합니다.")
     public ResponseEntity<List<LoveBoardResponse>> getMyLovedBoards(@PathVariable Long memberId){
         List<LoveBoardResponse> responses=loveService.getMyLovedBoards(memberId);

--- a/src/main/java/backend/hiteen/love/controller/LoveController.java
+++ b/src/main/java/backend/hiteen/love/controller/LoveController.java
@@ -1,14 +1,14 @@
 package backend.hiteen.love.controller;
 
+import backend.hiteen.love.dto.LoveBoardResponse;
 import backend.hiteen.love.service.LoveService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +23,12 @@ public class LoveController {
     public ResponseEntity<String> loveBoard(@PathVariable Long memberId, @PathVariable Long boardId){
         String message=loveService.updateLoveBoard(memberId,boardId);
         return ResponseEntity.ok(message);
+    }
 
+    @GetMapping("/members/{memberId}/boards/loves")
+    @Operation(summary = "내가 좋아요 한 게시글 전체 조회", description = "사용자가 좋아요 한 게시글을 전체 조회합니다.")
+    public ResponseEntity<List<LoveBoardResponse>> getMyLovedBoards(@PathVariable Long memberId){
+        List<LoveBoardResponse> responses=loveService.getMyLovedBoards(memberId);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/backend/hiteen/love/dto/LoveBoardResponse.java
+++ b/src/main/java/backend/hiteen/love/dto/LoveBoardResponse.java
@@ -1,0 +1,30 @@
+package backend.hiteen.love.dto;
+
+import backend.hiteen.board.entity.Board;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class LoveBoardResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private int loveCount;
+    private int scrapCount;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+
+    public LoveBoardResponse(Board board){
+        this.id= board.getId();;
+        this.title= board.getTitle();
+        this.content= board.getContent();
+        this.loveCount=board.getLoveCount();
+        this.scrapCount=board.getScrapCount();
+        this.createdDate=board.getCreatedDate();
+    }
+
+}

--- a/src/main/java/backend/hiteen/love/repository/LoveRepository.java
+++ b/src/main/java/backend/hiteen/love/repository/LoveRepository.java
@@ -4,9 +4,14 @@ import backend.hiteen.board.entity.Board;
 import backend.hiteen.love.entity.Love;
 import backend.hiteen.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LoveRepository extends JpaRepository<Love,Long> {
     Optional<Love> findByMemberAndBoard(Member member, Board board);
+
+    @Query("SELECT l.board FROM Love l WHERE l.member.id=:memberId")
+    List<Board> findLovedBoardsByMemberId(Long memberId);
 }

--- a/src/main/java/backend/hiteen/love/service/LoveService.java
+++ b/src/main/java/backend/hiteen/love/service/LoveService.java
@@ -2,6 +2,7 @@ package backend.hiteen.love.service;
 
 import backend.hiteen.board.entity.Board;
 import backend.hiteen.board.repository.BoardRepository;
+import backend.hiteen.love.dto.LoveBoardResponse;
 import backend.hiteen.love.entity.Love;
 import backend.hiteen.love.repository.LoveRepository;
 import backend.hiteen.member.entity.Member;
@@ -9,6 +10,9 @@ import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +36,12 @@ public class LoveService {
         }
          board.decreaseLoveCount();
         return deleteLove(member,board);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LoveBoardResponse> getMyLovedBoards(Long memberId){
+        List<Board> boards=loveRepository.findLovedBoardsByMemberId(memberId);
+        return boards.stream().map(LoveBoardResponse::new).collect(Collectors.toList());
     }
 
     private boolean hasLoveBoard(Member member, Board board){

--- a/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
+++ b/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
@@ -18,14 +18,14 @@ public class ScrapController {
 
     private final ScrapService scrapService;
 
-    @PostMapping("/members/{memberId}/boards/{boardId}/scraps")
+    @PostMapping("/members/{memberId}/scraps/boards/{boardId}")
     @Operation(summary = "스크랩", description = "사용자가 게시글을 스크랩/스크랩 취소 합니다.")
     public ResponseEntity<String> scrapBoard(@PathVariable Long memberId, @PathVariable Long boardId){
         String message=scrapService.updateScrapBoard(memberId,boardId);
         return ResponseEntity.ok(message);
     }
 
-    @GetMapping("/members/{memberId}/boards/scraps")
+    @GetMapping("/members/{memberId}/scraps/boards")
     @Operation(summary = "내가 스크랩 한 게시글 전체 조회", description = "사용자가 스크랩 한 게시글을 전체 조회합니다.")
     public ResponseEntity<List<ScrapBoardResponse>> getMyScrapedBoards(@PathVariable Long memberId){
         List<ScrapBoardResponse> responses=scrapService.getMyScrapedBoards(memberId);

--- a/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
+++ b/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
@@ -1,14 +1,14 @@
 package backend.hiteen.scrap.controller;
 
+import backend.hiteen.scrap.dto.ScrapBoardResponse;
 import backend.hiteen.scrap.service.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping
@@ -23,5 +23,12 @@ public class ScrapController {
     public ResponseEntity<String> scrapBoard(@PathVariable Long memberId, @PathVariable Long boardId){
         String message=scrapService.updateScrapBoard(memberId,boardId);
         return ResponseEntity.ok(message);
+    }
+
+    @GetMapping("/members/{memberId}/boards/scraps")
+    @Operation(summary = "내가 스크랩 한 게시글 전체 조회", description = "사용자가 스크랩 한 게시글을 전체 조회합니다.")
+    public ResponseEntity<List<ScrapBoardResponse>> getMyScrapedBoards(@PathVariable Long memberId){
+        List<ScrapBoardResponse> responses=scrapService.getMyScrapedBoards(memberId);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/backend/hiteen/scrap/dto/ScrapBoardResponse.java
+++ b/src/main/java/backend/hiteen/scrap/dto/ScrapBoardResponse.java
@@ -1,2 +1,30 @@
-package backend.hiteen.scrap.dto;public class ScrapBoardResponse {
+package backend.hiteen.scrap.dto;
+
+import backend.hiteen.board.entity.Board;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ScrapBoardResponse {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final int loveCount;
+    private final int scrapCount;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdDate;
+
+    public ScrapBoardResponse(Board board){
+        this.id= board.getId();
+        this.title= board.getTitle();
+        this.content= board.getContent();
+        this.loveCount= board.getLoveCount();
+        this.scrapCount= board.getScrapCount();
+        this.createdDate=board.getCreatedDate();
+    }
+
 }

--- a/src/main/java/backend/hiteen/scrap/dto/ScrapBoardResponse.java
+++ b/src/main/java/backend/hiteen/scrap/dto/ScrapBoardResponse.java
@@ -1,0 +1,2 @@
+package backend.hiteen.scrap.dto;public class ScrapBoardResponse {
+}

--- a/src/main/java/backend/hiteen/scrap/repository/ScrapRepository.java
+++ b/src/main/java/backend/hiteen/scrap/repository/ScrapRepository.java
@@ -4,10 +4,14 @@ import backend.hiteen.board.entity.Board;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.scrap.entity.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap,Long>{
-
     Optional<Scrap> findByMemberAndBoard(Member member, Board board);
+
+    @Query("SELECT s.board FROM Scrap s WHERE s.member.id=:memberId")
+    List<Board> findScrapedBoardsByMemberId(Long memberId);
 }

--- a/src/main/java/backend/hiteen/scrap/service/ScrapService.java
+++ b/src/main/java/backend/hiteen/scrap/service/ScrapService.java
@@ -4,11 +4,15 @@ import backend.hiteen.board.entity.Board;
 import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
+import backend.hiteen.scrap.dto.ScrapBoardResponse;
 import backend.hiteen.scrap.entity.Scrap;
 import backend.hiteen.scrap.repository.ScrapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +36,13 @@ public class ScrapService {
         }
         board.decreaseScrapCount();
         return deleteScrap(member,board);
+    }
+
+    //내가 스크랩 한 게시글 조회
+    @Transactional(readOnly = true)
+    public List<ScrapBoardResponse> getMyScrapedBoards(Long memebrId){
+        List<Board> boards=scrapRepository.findScrapedBoardsByMemberId(memebrId);
+        return boards.stream().map(ScrapBoardResponse::new).collect(Collectors.toList());
     }
 
     private boolean hasScrapBoard(Member member, Board board){


### PR DESCRIPTION
# 설명
- 내가 좋아요/스크랩 한 게시글 전체 조회 api 도메인 변경

# 작업 내용
- 좋아요 한 게시글 전체 조회 api board 도메인 -> love 도메인으로 이동
- 스크랩 한 게시글 전체 조회 api board 도메인 -> scrap 도메인으로 이동
- board/scrap/love 관련 api 엔드포인트 수정

# 구현 예정
- 게시글/스크랩/좋아요 관련 api 익명 처리
- 각 api jwt 적용하기