### PR TITLE
[feat/#57]: 게시글 작성자 공개 여부 기능 추가

### DIFF
--- a/src/main/java/backend/hiteen/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/backend/hiteen/board/dto/request/BoardCreateRequest.java
@@ -1,6 +1,9 @@
 package backend.hiteen.board.dto.request;
 
+import backend.hiteen.board.entity.DisclosureStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +17,14 @@ public class BoardCreateRequest {
 
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
+
+    @NotNull(message = "실명 공개 여부를 선택해주세요.")
+    @Schema(
+            description = "작성자 실명 공개 여부\n- PUBLIC: 실명 공개\n- ANONYMOUS: 익명",
+            example = "ANONYMOUS",
+            allowableValues = {"PUBLIC", "ANONYMOUS"}
+    )
+    private DisclosureStatus disclosureStatus;
 
 }
 

--- a/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
+++ b/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
@@ -1,6 +1,7 @@
 package backend.hiteen.board.dto.response;
 
 import backend.hiteen.board.entity.Board;
+import backend.hiteen.board.entity.DisclosureStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class BoardResponse {
     private final Long id;
     private final String title;
     private final String content;
+    private final String writer;
     private final int loveCount;
     private final int scrapCount;
 
@@ -21,6 +23,7 @@ public class BoardResponse {
     public BoardResponse(Board board){
         this.id=board.getId();
         this.title=board.getTitle();
+        this.writer=board.getDisplayWriterName();
         this.content=board.getContent();
         this.loveCount=board.getLoveCount();
         this.scrapCount= board.getScrapCount();

--- a/src/main/java/backend/hiteen/board/entity/Board.java
+++ b/src/main/java/backend/hiteen/board/entity/Board.java
@@ -4,6 +4,7 @@ import backend.hiteen.global.entity.BaseTimeEntity;
 import backend.hiteen.love.entity.Love;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.scrap.entity.Scrap;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,10 @@ public class Board extends BaseTimeEntity {
     @Column(name = "board_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DisclosureStatus disclosureStatus;
 
     @Column(nullable = false)
     private String title;
@@ -45,16 +50,23 @@ public class Board extends BaseTimeEntity {
     private List<Scrap> scraps;
 
 
-    private Board(Member member, String title, String content){
+    private Board(Member member, String title, String content, DisclosureStatus disclosureStatus){
         this.member=member;
         this.title=title;
         this.content=content;
         this.loveCount=0;
         this.scrapCount=0;
+        this.disclosureStatus=disclosureStatus;
     }
 
-    public static Board create(Member member, String title, String content){
-        return new Board(member,title,content);
+    public static Board create(Member member, String title, String content, DisclosureStatus disclosureStatus){
+        return new Board(member,title,content,disclosureStatus);
+    }
+
+    public String getDisplayWriterName(){
+        return this.disclosureStatus==DisclosureStatus.PUBLIC
+                ? this.member.getName()
+                :"익명";
     }
 
     public void increaseLoveCount(){

--- a/src/main/java/backend/hiteen/board/entity/DisclosureStatus.java
+++ b/src/main/java/backend/hiteen/board/entity/DisclosureStatus.java
@@ -1,0 +1,12 @@
+package backend.hiteen.board.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Id;
+
+@Schema(description = "작성자 공개 여부")
+public enum DisclosureStatus {
+    @Schema(description = "실명")
+    PUBLIC,
+    @Schema(description = "익명")
+    ANONYMOUS
+}

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -25,7 +25,7 @@ public class BoardService {
 
         Member member=memberRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        Board board=Board.create(member,request.getTitle(),request.getContent());
+        Board board=Board.create(member,request.getTitle(),request.getContent(), request.getDisclosureStatus());
         boardRepository.save(board);
 
         return new BoardResponse(board);


### PR DESCRIPTION
#설명
- 게시글 작성 시 작성자 공개 여부 기능 추가

#작업내용
- 게시글 작성 시 사용자가 실명 공개 여부를 선택할 수 있도록 기능 추가
- `DisclosureStatus` enum(PUBLIC / ANONYMOUS) 적용
- 기본값: `ANONYMOUS`, 실명:`PUBLIC`
- BoardResponse에서 공개 여부에 따라 실명 또는 "익명"으로 작성자 이름 출력

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set and display author disclosure status (public or anonymous) when creating a board post.
  * Board posts now show the writer's name or "익명" (anonymous) based on the selected disclosure status.

* **Improvements**
  * Enhanced API documentation for new fields related to disclosure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->