### PR TITLE
[feat/#60]: 게시글 카테고리 추가

### DIFF
--- a/src/main/java/backend/hiteen/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/backend/hiteen/board/dto/request/BoardCreateRequest.java
@@ -1,5 +1,6 @@
 package backend.hiteen.board.dto.request;
 
+import backend.hiteen.board.entity.Category;
 import backend.hiteen.board.entity.DisclosureStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -25,6 +26,13 @@ public class BoardCreateRequest {
             allowableValues = {"PUBLIC", "ANONYMOUS"}
     )
     private DisclosureStatus disclosureStatus;
+
+    @NotNull(message = "카테고리를 선택해주세요")
+    @Schema(
+            description = "게시글 카테고리\n FREE:자유게시판 | SECRET:비밀게시판 | PROMOTION:홍보게시판 | INFORMATION:정보게시판 | GRADE1,2,3:학년게시판 ",
+            example = "FREE", allowableValues = {"FREE", "SECRET","PROMOTION", "INFORMATION", "GRADE1", "GRADE2", "GRADE3"}
+    )
+    private Category category;
 
 }
 

--- a/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
+++ b/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
@@ -14,6 +14,8 @@ public class BoardResponse {
     private final String title;
     private final String content;
     private final String writer;
+    private final String category;
+    private final String categoryLabel;
     private final int loveCount;
     private final int scrapCount;
 
@@ -22,8 +24,10 @@ public class BoardResponse {
 
     public BoardResponse(Board board){
         this.id=board.getId();
-        this.title=board.getTitle();
         this.writer=board.getDisplayWriterName();
+        this.category=board.getCategory().name();
+        this.categoryLabel=board.getCategoryLabel();
+        this.title=board.getTitle();
         this.content=board.getContent();
         this.loveCount=board.getLoveCount();
         this.scrapCount= board.getScrapCount();

--- a/src/main/java/backend/hiteen/board/entity/Board.java
+++ b/src/main/java/backend/hiteen/board/entity/Board.java
@@ -23,15 +23,19 @@ public class Board extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private DisclosureStatus disclosureStatus;
-
     @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)
     private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DisclosureStatus disclosureStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
 
     @Column
     private int loveCount;
@@ -50,23 +54,28 @@ public class Board extends BaseTimeEntity {
     private List<Scrap> scraps;
 
 
-    private Board(Member member, String title, String content, DisclosureStatus disclosureStatus){
+    private Board(Member member, String title, String content, DisclosureStatus disclosureStatus, Category category){
         this.member=member;
         this.title=title;
         this.content=content;
         this.loveCount=0;
         this.scrapCount=0;
         this.disclosureStatus=disclosureStatus;
+        this.category=category;
     }
 
-    public static Board create(Member member, String title, String content, DisclosureStatus disclosureStatus){
-        return new Board(member,title,content,disclosureStatus);
+    public static Board create(Member member, String title, String content, DisclosureStatus disclosureStatus,Category category){
+        return new Board(member,title,content,disclosureStatus,category);
     }
 
     public String getDisplayWriterName(){
         return this.disclosureStatus==DisclosureStatus.PUBLIC
                 ? this.member.getName()
                 :"익명";
+    }
+
+    public String getCategoryLabel(){
+        return this.category.getLabel();
     }
 
     public void increaseLoveCount(){

--- a/src/main/java/backend/hiteen/board/entity/Category.java
+++ b/src/main/java/backend/hiteen/board/entity/Category.java
@@ -1,0 +1,37 @@
+package backend.hiteen.board.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum Category {
+    @Schema(description = "자유게시판")
+    FREE("자유게시판"),
+
+    @Schema(description = "비밀게시판")
+    SECRET("비밀게시판"),
+
+    @Schema(description = "홍보게시판")
+    PROMOTION("홍보게시판"),
+
+    @Schema(description = "정보게시판")
+    INFORMATION("정보게시판"),
+
+    @Schema(description = "1학년게시판")
+    GRADE1("1학년 게시판"),
+
+    @Schema(description = "2학년게시판")
+    GRADE2("2학년 게시판"),
+
+    @Schema(description = "3학년게시판")
+    GRADE3("3학년 게시판");
+
+    private final String label;
+
+    Category(String label)
+    {
+        this.label=label;
+    }
+
+    public String getLabel(){
+        return label;
+    }
+}

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -25,7 +25,7 @@ public class BoardService {
 
         Member member=memberRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        Board board=Board.create(member,request.getTitle(),request.getContent(), request.getDisclosureStatus());
+        Board board=Board.create(member,request.getTitle(),request.getContent(), request.getDisclosureStatus(), request.getCategory());
         boardRepository.save(board);
 
         return new BoardResponse(board);


### PR DESCRIPTION
#설명
- 게시글 카테고리 기능 추가 및 한글 라벨 응답 처리

#작업 내용
- 게시글에 카테고리 기능 추가
- 자유게시판, 비밀게시판, 홍보게시판, 정보게시판, 학년별 게시판(GRADE1~3) enum으로 정의
- Board 엔티티에 category 필드 추가 및 생성자/팩토리 메서드 수정
- BoardResponse 응답 시 카테고리 한글 라벨로 변환하여 제공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for board categories, allowing users to select a category when creating a board.
  * Boards now display both the category and its label in board details and responses.

* **Documentation**
  * Enhanced API documentation to describe available board categories and provide examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->