### PR TITLE
[feat/#62] Refresh Token 기반 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/backend/hiteen/auth/controller/AuthController.java
+++ b/src/main/java/backend/hiteen/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package backend.hiteen.auth.controller;
 
-import backend.hiteen.auth.dto.LoginRequest;
+import backend.hiteen.auth.dto.request.LoginRequest;
+import backend.hiteen.auth.dto.request.TokenReissueRequest;
+import backend.hiteen.auth.dto.response.TokenResponse;
 import backend.hiteen.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,10 +22,18 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "사용자가 로그인 합니다.")
-    public ResponseEntity<String> login(@RequestBody @Valid LoginRequest request){
-        String token= authService.login(request.getEmail(), request.getPassword());
-        return ResponseEntity.ok(token);
+    public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest request){
+        TokenResponse tokenResponse= authService.login(request.getEmail(), request.getPassword());
+        return ResponseEntity.ok(tokenResponse);
     }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
+    public ResponseEntity<TokenResponse> reissue(@RequestBody TokenReissueRequest request) {
+        TokenResponse tokenResponse = authService.reissue(request.getRefreshToken());
+        return ResponseEntity.ok(tokenResponse);
+    }
+
     @GetMapping("/me")
     @Operation(summary = "로그인 된 사용자 정보 확인", description = "현재 인증된 사용자의 이메일 정보를 확인합니다.")
     public ResponseEntity<String> me() {

--- a/src/main/java/backend/hiteen/auth/dto/request/LoginRequest.java
+++ b/src/main/java/backend/hiteen/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package backend.hiteen.auth.dto;
+package backend.hiteen.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/backend/hiteen/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/backend/hiteen/auth/dto/request/TokenReissueRequest.java
@@ -1,2 +1,8 @@
-package backend.hiteen.auth.dto.request;public class TokenReissueRequest {
+package backend.hiteen.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequest {
+    private String refreshToken;
 }

--- a/src/main/java/backend/hiteen/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/backend/hiteen/auth/dto/request/TokenReissueRequest.java
@@ -1,0 +1,2 @@
+package backend.hiteen.auth.dto.request;public class TokenReissueRequest {
+}

--- a/src/main/java/backend/hiteen/auth/dto/response/TokenResponse.java
+++ b/src/main/java/backend/hiteen/auth/dto/response/TokenResponse.java
@@ -1,0 +1,12 @@
+package backend.hiteen.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/backend/hiteen/auth/entity/RefreshToken.java
+++ b/src/main/java/backend/hiteen/auth/entity/RefreshToken.java
@@ -1,0 +1,38 @@
+package backend.hiteen.auth.entity;
+
+import backend.hiteen.member.entity.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Builder
+    private RefreshToken(Member member, String token){
+        this.member=member;
+        this.token=token;
+    }
+
+    public void updateToken(String newToken){
+        this.token=newToken;
+    }
+}

--- a/src/main/java/backend/hiteen/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/backend/hiteen/auth/jwt/JwtTokenProvider.java
@@ -16,14 +16,23 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private  String secretKey;
 
-    private final long validity=1000L * 60 * 60; //토큰 유효시간:1시간
+    private final long accessTokenvalidity=1000L * 60 * 60; //토큰 유효시간:1시간
+    private final long refreshTokenvalidity=1000L*60*60*24*7; //토큰 유효시간 7일
 
     @PostConstruct
     protected void init(){
         this.secretKey= Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    public String createToken(String email){
+    public String createAccessToken(String email){
+        return createToken(email,accessTokenvalidity);
+    }
+
+    public String createRefreshToken(String email){
+        return createToken(email, refreshTokenvalidity);
+    }
+
+    public String createToken(String email, long validity){
         Claims claims= Jwts.claims().setSubject(email);
         Date now=new Date();
         Date expiry=new Date(now.getTime()+validity); //1시간 후 만료

--- a/src/main/java/backend/hiteen/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/backend/hiteen/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package backend.hiteen.auth.repository;
+
+import backend.hiteen.auth.entity.RefreshToken;
+import backend.hiteen.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByMember(Member member);
+}

--- a/src/main/java/backend/hiteen/auth/service/AuthService.java
+++ b/src/main/java/backend/hiteen/auth/service/AuthService.java
@@ -1,6 +1,9 @@
 package backend.hiteen.auth.service;
 
+import backend.hiteen.auth.dto.response.TokenResponse;
+import backend.hiteen.auth.entity.RefreshToken;
 import backend.hiteen.auth.jwt.JwtTokenProvider;
+import backend.hiteen.auth.repository.RefreshTokenRepository;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,19 +15,58 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public String login(String email, String password){
-        Member member=memberRepository.findByEmail(email)
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+    public TokenResponse login(String email, String password) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
-        if (!member.getPassword().isPasswordMatch(password,passwordEncoder)){
+        if (!member.getPassword().isPasswordMatch(password, passwordEncoder)) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        return jwtTokenProvider.createToken(member.getEmail());
+        String accessToken = jwtTokenProvider.createAccessToken(email);
+        String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+        refreshTokenRepository.findByMember(member).ifPresentOrElse(
+                existing -> {
+                existing.updateToken(refreshToken);
+                refreshTokenRepository.save(existing);
+                },
+                () -> {
+                    RefreshToken newRefreshToken = RefreshToken.builder()
+                            .member(member)
+                            .token(refreshToken)
+                            .build();
+                    refreshTokenRepository.save(newRefreshToken);
+                }
+        );
+
+        return new TokenResponse(accessToken,refreshToken);
     }
 
+    public TokenResponse reissue(String refreshToken){
+        if(!jwtTokenProvider.validateToken(refreshToken)){
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
 
+        String email=jwtTokenProvider.getEmail(refreshToken);
+        Member member=memberRepository.findByEmail(email)
+                .orElseThrow(()->new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        RefreshToken saved=refreshTokenRepository.findByMember(member)
+                .orElseThrow(()->new IllegalArgumentException("저장된 Refresh Token이 없습니다."));
+        if (!saved.getToken().equals(refreshToken)){
+            throw new IllegalArgumentException("Refresh Token이 일치하지 않습니다.");
+        }
+        String newAccessToken= jwtTokenProvider.createAccessToken(email);
+        String newRefreshToken= jwtTokenProvider.createRefreshToken(email);
+
+        saved.updateToken(newRefreshToken);
+        refreshTokenRepository.save(saved);
+
+        return new TokenResponse(newAccessToken,newRefreshToken);
+    }
 }

--- a/src/main/java/backend/hiteen/global/config/SecurityConfig.java
+++ b/src/main/java/backend/hiteen/global/config/SecurityConfig.java
@@ -28,10 +28,10 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**",
+                        .requestMatchers("/auth/login",
+                                         "/auth/reissue",
                                          "/members/sign-up",
                                          "/swagger-ui/**",
-                                         "/v3/api-docs/**",
                                          "/actuator/**"
                         ).permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
# 설명
- 로그인 시 access token, refresh token 둘 다 발급되도록 기능 추가
- 로그인 만료 시, 토큰 재발급 기능 구현

# 구현 내용
- Access Token + Refresh Token 동시 발급 로직 추가
- Refresh Token 엔티티 추가
- 토큰 재발급 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced refresh token support for authentication, enabling secure token renewal without re-login.
  * Added a new endpoint for token reissuance using refresh tokens.
  * Login now returns both access and refresh tokens in a structured response.

* **Bug Fixes**
  * Updated security settings to restrict unauthenticated access to only specific authentication endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->