### PR TITLE
[Refactor/#70] 예외처리 리팩토링 및 SuccessCode 적용

### DIFF
--- a/src/main/java/backend/hiteen/auth/controller/AuthController.java
+++ b/src/main/java/backend/hiteen/auth/controller/AuthController.java
@@ -39,9 +39,8 @@ public class AuthController {
 
     @GetMapping("/me")
     @Operation(summary = "로그인 된 사용자 정보 확인", description = "현재 인증된 사용자의 이메일 정보를 확인합니다.")
-    public ResponseEntity<ApiResponse<String>> me() {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        return ResponseEntity.status(SuccessCode.MEMBER_INFO_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_INFO_FETCHED,email));
+    public ResponseEntity<ApiResponse<String>> me(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ResponseEntity.status(SuccessCode.MEMBER_CURRENT_INFO_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_CURRENT_INFO_FETCHED,principal.getUsername()));
     }
 
 }

--- a/src/main/java/backend/hiteen/auth/controller/AuthController.java
+++ b/src/main/java/backend/hiteen/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import backend.hiteen.auth.dto.request.LoginRequest;
 import backend.hiteen.auth.dto.request.TokenReissueRequest;
 import backend.hiteen.auth.dto.response.TokenResponse;
 import backend.hiteen.auth.service.AuthService;
+import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,23 +24,23 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "사용자가 로그인 합니다.")
-    public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest request){
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@RequestBody @Valid LoginRequest request){
         TokenResponse tokenResponse= authService.login(request.getEmail(), request.getPassword());
-        return ResponseEntity.ok(tokenResponse);
+        return ResponseEntity.status(SuccessCode.MEMBER_LOGGED_IN.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_LOGGED_IN, tokenResponse));
     }
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
-    public ResponseEntity<TokenResponse> reissue(@RequestBody TokenReissueRequest request) {
+    public ResponseEntity<ApiResponse<TokenResponse>> reissue(@RequestBody TokenReissueRequest request) {
         TokenResponse tokenResponse = authService.reissue(request.getRefreshToken());
-        return ResponseEntity.ok(tokenResponse);
+        return ResponseEntity.status(SuccessCode.MEMBER_REISSUED.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_REISSUED, tokenResponse));
     }
 
     @GetMapping("/me")
     @Operation(summary = "로그인 된 사용자 정보 확인", description = "현재 인증된 사용자의 이메일 정보를 확인합니다.")
-    public ResponseEntity<String> me() {
+    public ResponseEntity<ApiResponse<String>> me() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        return ResponseEntity.ok("현재 로그인된 사용자: " + email);
+        return ResponseEntity.status(SuccessCode.MEMBER_INFO_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_INFO_FETCHED,email));
     }
 
 }

--- a/src/main/java/backend/hiteen/auth/service/AuthService.java
+++ b/src/main/java/backend/hiteen/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import backend.hiteen.auth.dto.response.TokenResponse;
 import backend.hiteen.auth.entity.RefreshToken;
 import backend.hiteen.auth.jwt.JwtTokenProvider;
 import backend.hiteen.auth.repository.RefreshTokenRepository;
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +23,10 @@ public class AuthService {
 
     public TokenResponse login(String email, String password) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (!member.getPassword().isPasswordMatch(password, passwordEncoder)) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new BusinessException(ErrorCode.MEMBER_PASSWORD_NOT_MATCH);
         }
 
         String accessToken = jwtTokenProvider.createAccessToken(email);
@@ -49,17 +51,17 @@ public class AuthService {
 
     public TokenResponse reissue(String refreshToken){
         if(!jwtTokenProvider.validateToken(refreshToken)){
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            throw new BusinessException(ErrorCode.MEMBER_REFRESH_TOKEN_MISMATCH);
         }
 
         String email=jwtTokenProvider.getEmail(refreshToken);
         Member member=memberRepository.findByEmail(email)
-                .orElseThrow(()->new IllegalArgumentException("회원을 찾을 수 없습니다."));
+                .orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         RefreshToken saved=refreshTokenRepository.findByMember(member)
-                .orElseThrow(()->new IllegalArgumentException("저장된 Refresh Token이 없습니다."));
+                .orElseThrow(()->new BusinessException(ErrorCode.MEMBER_REFRESH_TOKEN_NOT_FOUND));
         if (!saved.getToken().equals(refreshToken)){
-            throw new IllegalArgumentException("Refresh Token이 일치하지 않습니다.");
+            throw new BusinessException(ErrorCode.MEMBER_REFRESH_TOKEN_MISMATCH);
         }
         String newAccessToken= jwtTokenProvider.createAccessToken(email);
         String newRefreshToken= jwtTokenProvider.createRefreshToken(email);

--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -28,9 +28,9 @@ public class BoardController {
 
     @PostMapping
     @Operation(summary = "게시글 추가", description = "사용자가 게시글을 작성합니다.")
-    public ResponseEntity<ApiResponse<BoardResponse>> createBoard(@AuthenticationPrincipal String email,
+    public ResponseEntity<ApiResponse<BoardResponse>> createBoard(@AuthenticationPrincipal CustomUserPrincipal principal,
                                                                  @Valid @RequestBody BoardCreateRequest request){
-        BoardResponse response=boardService.createBoard(email,request);
+        BoardResponse response=boardService.createBoard(principal.getUsername(),request);
         return ResponseEntity.status(SuccessCode.BOARD_CREATED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_CREATED,response));
     }
 
@@ -51,8 +51,8 @@ public class BoardController {
 
     @GetMapping("/my")
     @Operation(summary = "내가 작성한 게시글 목록 조회", description = "사용자가 자신이 작성한 게시글 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllMyBoards(@AuthenticationPrincipal String email){
-        List<BoardResponse> responses=boardService.getAllMyBoards(email);
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllMyBoards(@AuthenticationPrincipal CustomUserPrincipal principal){
+        List<BoardResponse> responses=boardService.getAllMyBoards(principal.getUsername());
         return ResponseEntity.status(SuccessCode.MY_BOARD_LIST_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MY_BOARD_LIST_FETCHED, responses));
     }
 

--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -4,6 +4,8 @@ package backend.hiteen.board.controller;
 import backend.hiteen.board.dto.request.BoardCreateRequest;
 import backend.hiteen.board.dto.response.BoardResponse;
 import backend.hiteen.board.service.BoardService;
+import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -25,32 +27,32 @@ public class BoardController {
 
     @PostMapping
     @Operation(summary = "게시글 추가", description = "사용자가 게시글을 작성합니다.")
-    public ResponseEntity<BoardResponse> createBoard(@AuthenticationPrincipal String email,
-            @Valid @RequestBody BoardCreateRequest request){
+    public ResponseEntity<ApiResponse<BoardResponse>> createBoard(@AuthenticationPrincipal String email,
+                                                                 @Valid @RequestBody BoardCreateRequest request){
         BoardResponse response=boardService.createBoard(email,request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(SuccessCode.BOARD_CREATED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_CREATED,response));
     }
 
 
     @GetMapping("/boards")
     @Operation(summary = "전체 게시글 목록 조회", description = "모든 사용자가 작성한 게시글을 조회합니다.")
-    public ResponseEntity<List<BoardResponse>> getAllBoards(){
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllBoards(){
         List<BoardResponse> responses=boardService.getAllBoards();
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.status(SuccessCode.BOARD_ALL_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_ALL_FETCHED, responses));
     }
 
     @GetMapping("/{boardId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글 ID를 통해 특정 게시글의 상세 내용을 조회합니다.")
-    public ResponseEntity<BoardResponse> getBoardById(@PathVariable Long boardId){
+    public ResponseEntity<ApiResponse<BoardResponse>> getBoardById(@PathVariable Long boardId){
         BoardResponse boardResponse=boardService.getBoardById(boardId);
-        return ResponseEntity.ok(boardResponse);
+        return ResponseEntity.status(SuccessCode.BOARD_DETAIL_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_DETAIL_FETCHED,boardResponse));
     }
 
     @GetMapping("/my")
     @Operation(summary = "내가 작성한 게시글 목록 조회", description = "사용자가 자신이 작성한 게시글 목록을 조회합니다.")
-    public ResponseEntity<List<BoardResponse>> getAllMyBoards(@AuthenticationPrincipal String email){
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllMyBoards(@AuthenticationPrincipal String email){
         List<BoardResponse> responses=boardService.getAllMyBoards(email);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.status(SuccessCode.MY_BOARD_LIST_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MY_BOARD_LIST_FETCHED, responses));
     }
 
 }

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -4,6 +4,8 @@ import backend.hiteen.board.dto.request.BoardCreateRequest;
 import backend.hiteen.board.dto.response.BoardResponse;
 import backend.hiteen.board.entity.Board;
 import backend.hiteen.board.repository.BoardRepository;
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +25,7 @@ public class BoardService {
     @Transactional
     public BoardResponse createBoard(String email,final BoardCreateRequest request){
 
-        Member member=memberRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("존재하지 않는 회원입니다."));
+        Member member=memberRepository.findByEmail(email).orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         Board board=Board.create(member,request.getTitle(),request.getContent(), request.getDisclosureStatus(), request.getCategory());
         boardRepository.save(board);
@@ -43,7 +45,7 @@ public class BoardService {
     @Transactional
     public BoardResponse getBoardById(Long boardId){
         Board board=boardRepository.findById(boardId)
-                .orElseThrow(()->new IllegalArgumentException("게시글이 존재하지 않습니다."));
+                .orElseThrow(()->new BusinessException(ErrorCode.BOARD_NOT_FOUND));
         board.increaseViewCount();
         return new BoardResponse(board);
     }
@@ -52,7 +54,7 @@ public class BoardService {
     @Transactional(readOnly = true)
     public List<BoardResponse> getAllMyBoards(String email){
 
-        Member member=memberRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("존재하지 않는 회원입니다."));
+        Member member=memberRepository.findByEmail(email).orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Board> boards=boardRepository.findAllByMember(member);
 

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     //board
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
+    BOARD_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 작성에 실패했습니다."),
 
     //comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -23,8 +23,8 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
 
     //love
-    LOVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요를 눌렀습니다."),
-    LOVE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 정보가 존재하지 않습니다."),
+    LOVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
+    LOVE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
 
     //scrap
     SCRAP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스크랩한 게시글입니다."),

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -9,6 +9,12 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
 
     //member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    MEMBER_PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 정보가 유효하지 않습니다."),
+    MEMBER_REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 Refresh Token이 없습니다."),
+    MEMBER_REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
 
     //board
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
@@ -17,8 +23,12 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
 
     //love
+    LOVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요를 눌렀습니다."),
+    LOVE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 정보가 존재하지 않습니다."),
 
     //scrap
+    SCRAP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스크랩한 게시글입니다."),
+    SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "스크랩 정보가 존재하지 않습니다."),
 
     //message
     MESSAGE_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "쪽지방을 찾을 수 없습니다."),

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -25,6 +25,9 @@ public enum SuccessCode {
     LOVED_BOARDS_FETCHED(HttpStatus.OK, "좋아요한 게시글 목록을 조회했습니다."),
 
     //scrap
+    SCRAP_CREATED(HttpStatus.CREATED, "게시글이 스크랩되었습니다."),
+    SCRAP_DELETED(HttpStatus.OK, "게시글 스크랩이 취소되었습니다."),
+    SCRAPED_BOARDS_FETCHED(HttpStatus.OK, "스크랩한 게시글 목록을 조회했습니다."),
 
     //message
     MESSAGE_ROOM_CREATED(HttpStatus.CREATED, "쪽지방이 생성되었습니다."),

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -7,12 +7,12 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     //member
+    MEMBER_REGISTERED(HttpStatus.CREATED, "회원가입이 완료되었습니다."),
     MEMBER_FETCHED(HttpStatus.OK, "회원 정보를 조회합니다."),
     MEMBER_UPDATED(HttpStatus.OK, "회원 정보를 수정합니다."),
-    MEMBER_REGISTERED(HttpStatus.CREATED, "회원가입이 완료되었습니다."),
     MEMBER_LOGGED_IN(HttpStatus.OK, "로그인이 완료되었습니다."),
     MEMBER_REISSUED(HttpStatus.OK, "토큰이 재발급되었습니다."),
-    MEMBER_INFO_FETCHED(HttpStatus.OK, "회원 정보를 조회했습니다."),
+    MEMBER_CURRENT_INFO_FETCHED(HttpStatus.OK, "현재 로그인 된 사용자입니다."),
 
 
     //board

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -7,7 +7,10 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     //member
-
+    MEMBER_REGISTERED(HttpStatus.CREATED, "회원가입이 완료되었습니다."),
+    MEMBER_LOGGED_IN(HttpStatus.OK, "로그인이 완료되었습니다."),
+    MEMBER_REISSUED(HttpStatus.OK, "토큰이 재발급되었습니다."),
+    MEMBER_INFO_FETCHED(HttpStatus.OK, "회원 정보를 조회했습니다."),
     //board
 
     //comment

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -13,6 +13,10 @@ public enum SuccessCode {
     MEMBER_INFO_FETCHED(HttpStatus.OK, "회원 정보를 조회했습니다."),
 
     //board
+    BOARD_CREATED(HttpStatus.CREATED, "게시글이 등록되었습니다."),
+    BOARD_DETAIL_FETCHED(HttpStatus.OK, "게시글을 단일 조회했습니다."),
+    BOARD_ALL_FETCHED(HttpStatus.OK, "모든 게시글 목록을 조회했습니다."),
+    MY_BOARD_LIST_FETCHED(HttpStatus.OK, "내가 작성한 게시글 목록을 조회했습니다."),
 
     //comment
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -11,13 +11,18 @@ public enum SuccessCode {
     MEMBER_LOGGED_IN(HttpStatus.OK, "로그인이 완료되었습니다."),
     MEMBER_REISSUED(HttpStatus.OK, "토큰이 재발급되었습니다."),
     MEMBER_INFO_FETCHED(HttpStatus.OK, "회원 정보를 조회했습니다."),
+
     //board
 
     //comment
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),
     REPLY_CREATED(HttpStatus.CREATED,"대댓글이 등록되었습니다."),
     COMMENT_FETCHED(HttpStatus.OK, "댓글 목록을 불러왔습니다."),
+
     //love
+    LOVE_CREATED(HttpStatus.CREATED, "게시글에 좋아요를 눌렀습니다."),
+    LOVE_DELETED(HttpStatus.OK, "게시글 좋아요를 취소했습니다."),
+    LOVED_BOARDS_FETCHED(HttpStatus.OK, "좋아요한 게시글 목록을 조회했습니다."),
 
     //scrap
 

--- a/src/main/java/backend/hiteen/love/controller/LoveController.java
+++ b/src/main/java/backend/hiteen/love/controller/LoveController.java
@@ -1,5 +1,6 @@
 package backend.hiteen.love.controller;
 
+import backend.hiteen.auth.security.CustomUserPrincipal;
 import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.love.dto.LoveBoardResponse;
@@ -24,7 +25,8 @@ public class LoveController {
 
     @PostMapping
     @Operation(summary = "좋아요", description = "사용자가 좋아요를 추가하거나 취소합니다.")
-    public ResponseEntity<ApiResponse<String>> loveBoard(@AuthenticationPrincipal String email, @RequestParam Long boardId){
+    public ResponseEntity<ApiResponse<String>> loveBoard(@AuthenticationPrincipal CustomUserPrincipal principal, @RequestParam Long boardId){
+        String email=principal.getUsername();
         LoveActionResult result=loveService.updateLoveBoard(email,boardId);
 
         if (result==LoveActionResult.CREATED){
@@ -36,7 +38,8 @@ public class LoveController {
 
     @GetMapping("/my")
     @Operation(summary = "내가 좋아요 한 게시글 전체 조회", description = "사용자가 좋아요 한 게시글을 전체 조회합니다.")
-    public ResponseEntity<ApiResponse<List<LoveBoardResponse>>> getMyLovedBoards(@AuthenticationPrincipal String email){
+    public ResponseEntity<ApiResponse<List<LoveBoardResponse>>> getMyLovedBoards(@AuthenticationPrincipal CustomUserPrincipal principal){
+        String email=principal.getUsername();
         List<LoveBoardResponse> responses=loveService.getMyLovedBoards(email);
         return ResponseEntity.status(SuccessCode.LOVED_BOARDS_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.LOVED_BOARDS_FETCHED, responses));
     }

--- a/src/main/java/backend/hiteen/love/controller/LoveController.java
+++ b/src/main/java/backend/hiteen/love/controller/LoveController.java
@@ -1,6 +1,9 @@
 package backend.hiteen.love.controller;
 
+import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.love.dto.LoveBoardResponse;
+import backend.hiteen.love.entity.LoveActionResult;
 import backend.hiteen.love.service.LoveService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,15 +24,20 @@ public class LoveController {
 
     @PostMapping
     @Operation(summary = "좋아요", description = "사용자가 좋아요를 추가하거나 취소합니다.")
-    public ResponseEntity<String> loveBoard(@AuthenticationPrincipal String email, @RequestParam Long boardId){
-        String message=loveService.updateLoveBoard(email,boardId);
-        return ResponseEntity.ok(message);
+    public ResponseEntity<ApiResponse<String>> loveBoard(@AuthenticationPrincipal String email, @RequestParam Long boardId){
+        LoveActionResult result=loveService.updateLoveBoard(email,boardId);
+
+        if (result==LoveActionResult.CREATED){
+            return ResponseEntity.status(SuccessCode.LOVE_CREATED.getStatus()).body(ApiResponse.success(SuccessCode.LOVE_CREATED));
+        } else {
+            return ResponseEntity.status(SuccessCode.LOVE_DELETED.getStatus()).body(ApiResponse.success(SuccessCode.LOVE_DELETED));
+        }
     }
 
     @GetMapping("/my")
     @Operation(summary = "내가 좋아요 한 게시글 전체 조회", description = "사용자가 좋아요 한 게시글을 전체 조회합니다.")
-    public ResponseEntity<List<LoveBoardResponse>> getMyLovedBoards(@AuthenticationPrincipal String email){
+    public ResponseEntity<ApiResponse<List<LoveBoardResponse>>> getMyLovedBoards(@AuthenticationPrincipal String email){
         List<LoveBoardResponse> responses=loveService.getMyLovedBoards(email);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.status(SuccessCode.LOVED_BOARDS_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.LOVED_BOARDS_FETCHED, responses));
     }
 }

--- a/src/main/java/backend/hiteen/love/entity/LoveActionResult.java
+++ b/src/main/java/backend/hiteen/love/entity/LoveActionResult.java
@@ -1,0 +1,6 @@
+package backend.hiteen.love.entity;
+
+public enum LoveActionResult {
+    CREATED,
+    DELETED
+}

--- a/src/main/java/backend/hiteen/love/service/LoveService.java
+++ b/src/main/java/backend/hiteen/love/service/LoveService.java
@@ -2,8 +2,11 @@ package backend.hiteen.love.service;
 
 import backend.hiteen.board.entity.Board;
 import backend.hiteen.board.repository.BoardRepository;
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.love.dto.LoveBoardResponse;
 import backend.hiteen.love.entity.Love;
+import backend.hiteen.love.entity.LoveActionResult;
 import backend.hiteen.love.repository.LoveRepository;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
@@ -23,26 +26,28 @@ public class LoveService {
 
     // 좋아요 기능
     @Transactional
-    public String updateLoveBoard(String email, Long boardId){
+    public LoveActionResult updateLoveBoard(String email, Long boardId){
 
         Board board=boardRepository.findById(boardId)
-                .orElseThrow(()->new IllegalArgumentException("게시글이 존재하지 않습니다."));
+                .orElseThrow(()->new BusinessException(ErrorCode.BOARD_NOT_FOUND));
 
-        Member member=memberRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("사용자가 존재하지 않습니다."));
+        Member member=memberRepository.findByEmail(email).orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         if(!isBoardLoved(member,board)){
             board.increaseLoveCount();
-            return createLove(member,board);
+            createLove(member,board);
+            return LoveActionResult.CREATED;
         }
          board.decreaseLoveCount();
-        return deleteLove(member,board);
+        deleteLove(member,board);
+        return LoveActionResult.DELETED;
     }
 
 
     @Transactional(readOnly = true)
     public List<LoveBoardResponse> getMyLovedBoards(String email){
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Board> boards=loveRepository.findLovedBoardsByMemberId(member.getId());
 
@@ -53,17 +58,15 @@ public class LoveService {
         return loveRepository.findByMemberAndBoard(member,board).isPresent();
     }
 
-    private String createLove(Member member, Board board){
+    private void createLove(Member member, Board board){
         Love love=new Love(member,board);
         loveRepository.save(love);
-        return "좋아요를 눌렀습니다.";
     }
 
-    private String deleteLove(Member member, Board board){
+    private void deleteLove(Member member, Board board){
         Love love=loveRepository.findByMemberAndBoard(member,board)
-                .orElseThrow(()-> new IllegalArgumentException("좋아요가 없습니다."));
+                .orElseThrow(()-> new BusinessException(ErrorCode.LOVE_NOT_FOUND));
         loveRepository.delete(love);
-        return "좋아요를 취소했습니다.";
     }
 
 

--- a/src/main/java/backend/hiteen/member/controller/MemberController.java
+++ b/src/main/java/backend/hiteen/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package backend.hiteen.member.controller;
 
+import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.member.dto.request.MemberCreateRequest;
 import backend.hiteen.member.dto.response.MemberResponse;
 import backend.hiteen.member.service.MemberService;
@@ -24,8 +26,8 @@ public class MemberController {
 
     @PostMapping("/sign-up")
     @Operation(summary = "회원가입",description = "사용자가 회원가입을 합니다. 비밀번호는 6자 이상이며, 영문자와 숫자를 최소 1자 이상 포함해야 합니다.")
-    public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody MemberCreateRequest request){
+    public ResponseEntity<ApiResponse<MemberResponse>> signUp(@Valid @RequestBody MemberCreateRequest request){
         MemberResponse memberResponse= memberService.signUp(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(memberResponse);
+        return ResponseEntity.status(SuccessCode.MEMBER_REGISTERED.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_REGISTERED, memberResponse));
     }
 }

--- a/src/main/java/backend/hiteen/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/backend/hiteen/member/dto/request/MemberCreateRequest.java
@@ -27,9 +27,6 @@ public class MemberCreateRequest {
     @NotBlank(message = "이름을 입력해주세요.")
     private String name;
 
-    @NotBlank(message = "닉네임을 입력해주세요.")
-    private String nickname;
-
     @NotNull(message = "학교를 입력해주세요.")
     private Long schoolId;
 
@@ -42,7 +39,6 @@ public class MemberCreateRequest {
                 .email(email)
                 .password(password)
                 .name(name)
-                .nickname(nickname)
                 .school(school)
                 .gradeNumber(gradeNumber)
                 .classNumber(classNumber)

--- a/src/main/java/backend/hiteen/member/dto/response/MemberResponse.java
+++ b/src/main/java/backend/hiteen/member/dto/response/MemberResponse.java
@@ -9,7 +9,6 @@ public class MemberResponse {
 
     private final String email;
     private final String name;
-    private final String nickname;
     private final int gradeNumber;
     private final int classNumber;
     private final SchoolResponse school;
@@ -17,7 +16,6 @@ public class MemberResponse {
     public MemberResponse(Member member){
         this.email=member.getEmail();
         this.name=member.getName();
-        this.nickname=member.getNickname();
         this.gradeNumber=member.getGradeNumber();
         this.classNumber=member.getClassNumber();
         this.school = new SchoolResponse(member.getSchool());

--- a/src/main/java/backend/hiteen/member/entity/Member.java
+++ b/src/main/java/backend/hiteen/member/entity/Member.java
@@ -34,9 +34,6 @@ public class Member {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
-    private String nickname;
-
     @ManyToOne
     @JoinColumn(name = "school_id")
     private School school;
@@ -57,12 +54,11 @@ public class Member {
     private List<Scrap> scraps;
 
     @Builder
-    private Member(String email, String password, String name, String nickname,
+    private Member(String email, String password, String name,
                    School school, int gradeNumber, int classNumber, PasswordEncoder encoder) {
         this.email = email;
         this.password = new Password(password, encoder);
         this.name = name;
-        this.nickname = nickname;
         this.school = school;
         this.classNumber = classNumber;
         this.gradeNumber = gradeNumber;

--- a/src/main/java/backend/hiteen/member/entity/Member.java
+++ b/src/main/java/backend/hiteen/member/entity/Member.java
@@ -79,7 +79,6 @@ public class Member {
         if (password != null) this.password = new Password(password, encoder);
 
         this.name = name;
-        this.nickname = nickname;
         this.gradeNumber = gradeNumber;
         this.classNumber = classNumber;
     }

--- a/src/main/java/backend/hiteen/member/repository/MemberRepository.java
+++ b/src/main/java/backend/hiteen/member/repository/MemberRepository.java
@@ -10,7 +10,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member,Long> {
     boolean existsByEmail(String email);
-    boolean existsByNickname(String nickName);
-
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/backend/hiteen/member/service/MemberService.java
+++ b/src/main/java/backend/hiteen/member/service/MemberService.java
@@ -77,11 +77,6 @@ public class MemberService {
             validatePassword(newPw, request.getPasswordConfirm());
         }
 
-        String newNick = request.getNickname();
-        if (newNick != null && !member.getNickname().equals(newNick)) {
-            validateDuplicateNickname(newNick);
-        }
-
         member.updateProfile(
                 request.getName(),
                 request.getNickname(),

--- a/src/main/java/backend/hiteen/member/service/MemberService.java
+++ b/src/main/java/backend/hiteen/member/service/MemberService.java
@@ -1,8 +1,10 @@
 package backend.hiteen.member.service;
 
+import backend.hiteen.common.response.ErrorCode;
 import backend.hiteen.externalapi.school.entity.School;
 import backend.hiteen.externalapi.school.exception.SchoolNotFoundException;
 import backend.hiteen.externalapi.school.reporitory.SchoolRepository;
+import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.dto.request.MemberCreateRequest;
 import backend.hiteen.member.dto.response.MemberResponse;
 import backend.hiteen.member.entity.Member;
@@ -24,7 +26,6 @@ public class MemberService {
     @Transactional
     public MemberResponse signUp(final MemberCreateRequest request) {
         validateDuplicateEmail(request.getEmail());
-        validateDuplicateNickname(request.getNickname());
         validatePassword(request.getPassword(), request.getPasswordConfirm());
 
         School school = schoolRepository.findById(request.getSchoolId())
@@ -39,21 +40,15 @@ public class MemberService {
     //이메일 중복 예외처리
     private void validateDuplicateEmail(String email){
         if(memberRepository.existsByEmail(email)){
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+            throw new BusinessException(ErrorCode.MEMBER_ALREADY_EXISTS);
         }
     }
 
-    //닉네임 중복 예외처리
-    private void validateDuplicateNickname(String nickName){
-        if(memberRepository.existsByNickname(nickName)){
-            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
-        }
-    }
 
     //비밀번호 확인 예외처리
     private void validatePassword(String password, String passwordConfirm){
         if(!password.equals(passwordConfirm)){
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new BusinessException(ErrorCode.MEMBER_PASSWORD_NOT_MATCH);
         }
     }
 }

--- a/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
+++ b/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
@@ -1,6 +1,9 @@
 package backend.hiteen.scrap.controller;
 
+import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.scrap.dto.ScrapBoardResponse;
+import backend.hiteen.scrap.entity.ScrapActionResult;
 import backend.hiteen.scrap.service.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,15 +24,20 @@ public class ScrapController {
 
     @PostMapping
     @Operation(summary = "스크랩", description = "사용자가 게시글을 스크랩/스크랩 취소 합니다.")
-    public ResponseEntity<String> scrapBoard(@AuthenticationPrincipal String email, @RequestParam Long boardId){
-        String message=scrapService.updateScrapBoard(email,boardId);
-        return ResponseEntity.ok(message);
+    public ResponseEntity<ApiResponse<String>> scrapBoard(@AuthenticationPrincipal String email, @RequestParam Long boardId){
+        ScrapActionResult result=scrapService.updateScrapBoard(email,boardId);
+
+        if (result==ScrapActionResult.CREATED){
+            return ResponseEntity.status(SuccessCode.SCRAP_CREATED.getStatus()).body(ApiResponse.success(SuccessCode.SCRAP_CREATED));
+        } else{
+            return ResponseEntity.status(SuccessCode.SCRAP_DELETED.getStatus()).body(ApiResponse.success(SuccessCode.SCRAP_DELETED));
+        }
     }
 
     @GetMapping("/my")
     @Operation(summary = "내가 스크랩 한 게시글 전체 조회", description = "사용자가 스크랩 한 게시글을 전체 조회합니다.")
-    public ResponseEntity<List<ScrapBoardResponse>> getMyScrapedBoards(@AuthenticationPrincipal String email){
+    public ResponseEntity<ApiResponse<List<ScrapBoardResponse>>> getMyScrapedBoards(@AuthenticationPrincipal String email){
         List<ScrapBoardResponse> responses=scrapService.getMyScrapedBoards(email);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.status(SuccessCode.SCRAPED_BOARDS_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.SCRAPED_BOARDS_FETCHED, responses));
     }
 }

--- a/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
+++ b/src/main/java/backend/hiteen/scrap/controller/ScrapController.java
@@ -25,8 +25,9 @@ public class ScrapController {
 
     @PostMapping
     @Operation(summary = "스크랩", description = "사용자가 게시글을 스크랩/스크랩 취소 합니다.")
-    public ResponseEntity<String> scrapBoard(@AuthenticationPrincipal CustomUserPrincipal principal, @RequestParam Long boardId){
+    public ResponseEntity<ApiResponse<String>> scrapBoard(@AuthenticationPrincipal CustomUserPrincipal principal, @RequestParam Long boardId){
         String email = principal.getUsername();
+        ScrapActionResult result = scrapService.updateScrapBoard(email, boardId);
 
         if (result==ScrapActionResult.CREATED){
             return ResponseEntity.status(SuccessCode.SCRAP_CREATED.getStatus()).body(ApiResponse.success(SuccessCode.SCRAP_CREATED));
@@ -37,7 +38,7 @@ public class ScrapController {
 
     @GetMapping("/my")
     @Operation(summary = "내가 스크랩 한 게시글 전체 조회", description = "사용자가 스크랩 한 게시글을 전체 조회합니다.")
-    public ResponseEntity<List<ScrapBoardResponse>> getMyScrapedBoards(@AuthenticationPrincipal CustomUserPrincipal principal){
+    public ResponseEntity<ApiResponse<List<ScrapBoardResponse>>> getMyScrapedBoards(@AuthenticationPrincipal CustomUserPrincipal principal){
         String email = principal.getUsername();
         List<ScrapBoardResponse> responses=scrapService.getMyScrapedBoards(email);
         return ResponseEntity.status(SuccessCode.SCRAPED_BOARDS_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.SCRAPED_BOARDS_FETCHED, responses));

--- a/src/main/java/backend/hiteen/scrap/entity/ScrapActionResult.java
+++ b/src/main/java/backend/hiteen/scrap/entity/ScrapActionResult.java
@@ -1,0 +1,5 @@
+package backend.hiteen.scrap.entity;
+
+public enum ScrapActionResult {
+    CREATED, DELETED
+}

--- a/src/main/java/backend/hiteen/scrap/service/ScrapService.java
+++ b/src/main/java/backend/hiteen/scrap/service/ScrapService.java
@@ -2,10 +2,13 @@ package backend.hiteen.scrap.service;
 
 import backend.hiteen.board.entity.Board;
 import backend.hiteen.board.repository.BoardRepository;
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
 import backend.hiteen.scrap.dto.ScrapBoardResponse;
 import backend.hiteen.scrap.entity.Scrap;
+import backend.hiteen.scrap.entity.ScrapActionResult;
 import backend.hiteen.scrap.repository.ScrapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,19 +26,21 @@ public class ScrapService {
 
     //스크랩 추가/취소
     @Transactional
-    public String updateScrapBoard(String email, Long boardId){
+    public ScrapActionResult updateScrapBoard(String email, Long boardId){
         Member member=memberRepository.findByEmail(email)
-                .orElseThrow(()->new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                .orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         Board board=boardRepository.findById(boardId)
-                .orElseThrow(()-> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+                .orElseThrow(()-> new BusinessException(ErrorCode.BOARD_NOT_FOUND));
 
         if (!isBoardScrapped(member, board)){
             board.increaseScrapCount();
-            return createScrap(member,board);
+            createScrap(member,board);
+            return ScrapActionResult.CREATED;
         }
         board.decreaseScrapCount();
-        return deleteScrap(member,board);
+        deleteScrap(member,board);
+        return ScrapActionResult.DELETED;
     }
 
     //내가 스크랩 한 게시글 조회
@@ -43,7 +48,7 @@ public class ScrapService {
     public List<ScrapBoardResponse> getMyScrapedBoards(String email){
 
         Member member=memberRepository.findByEmail(email)
-                .orElseThrow(()->new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                .orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Board> boards=scrapRepository.findScrapedBoardsByMemberId(member.getId());
 
@@ -54,16 +59,14 @@ public class ScrapService {
         return scrapRepository.findByMemberAndBoard(member,board).isPresent();
     }
 
-    private String createScrap(Member member, Board board){
+    private void createScrap(Member member, Board board){
         Scrap scrap=Scrap.create(member,board);
         scrapRepository.save(scrap);
-        return "스크랩이 되었습니다.";
     }
 
-    private String deleteScrap(Member member, Board board){
+    private void deleteScrap(Member member, Board board){
         Scrap scrap=scrapRepository.findByMemberAndBoard(member, board)
-                .orElseThrow(()-> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+                .orElseThrow(()-> new BusinessException(ErrorCode.SCRAP_NOT_FOUND));
         scrapRepository.delete(scrap);
-        return "스크랩이 취소되었습니다.";
     }
 }


### PR DESCRIPTION
#설명
- Member, Love, Scrap, Board 도메인에 대한 예외처리

#작업내용
- Member, Love, Scrap, Board 도메인에 대한 예외처리를 기존 IllegalArgumentException 기반 처리에서 BusinessException + `ErrorCode` 기반으로 리팩토링
- 도메인별 에러 상황에 맞는 ErrorCode 정의 및 적용
- 기존 하드코딩된 성공 메시지를 SuccessCode enum으로 통일하여 ApiResponse 응답 형식 일관화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses are now consistently wrapped in a standardized format, providing clear status codes and messages for all major endpoints (authentication, member, board, love, and scrap operations).
  * More detailed success and error codes have been added for improved feedback on various actions.

* **Bug Fixes**
  * Improved error handling with more specific error codes and structured business exceptions for authentication, board, love, and scrap operations.

* **Refactor**
  * The "nickname" field has been removed from all member-related requests, responses, and data storage.
  * Like ("love") and scrap actions now return clear, typed results indicating whether an action created or deleted an entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->