### PR TITLE
[feat/#78]: 인기 게시글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/backend/hiteen/auth/controller/AuthController.java
+++ b/src/main/java/backend/hiteen/auth/controller/AuthController.java
@@ -7,7 +7,6 @@ import backend.hiteen.auth.security.CustomUserPrincipal;
 import backend.hiteen.auth.service.AuthService;
 import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.SuccessCode;
-import backend.hiteen.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;

--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -56,4 +56,11 @@ public class BoardController {
         return ResponseEntity.status(SuccessCode.MY_BOARD_LIST_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MY_BOARD_LIST_FETCHED, responses));
     }
 
+    @GetMapping("/popular")
+    @Operation(summary ="인기게시글 목록 조회", description = "인기게시글을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getPopularBoards(){
+        List<BoardResponse> responses=boardService.getPopularBoards();
+        return ResponseEntity.status(SuccessCode.POPULAR_BOARD_ALL_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.POPULAR_BOARD_ALL_FETCHED, responses));
+    }
+
 }

--- a/src/main/java/backend/hiteen/board/repository/BoardRepository.java
+++ b/src/main/java/backend/hiteen/board/repository/BoardRepository.java
@@ -3,9 +3,13 @@ package backend.hiteen.board.repository;
 import backend.hiteen.board.entity.Board;
 import backend.hiteen.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board,Long> {
     List<Board> findAllByMember(Member member);
+    @Query("SELECT board FROM Board board WHERE (board.viewCount+board.loveCount)>=30")
+    List<Board> findPopularBoards();
+
 }

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -65,4 +65,11 @@ public class BoardService {
         return boards.stream().map(BoardResponse::new).toList();
     }
 
+    //인기게시글 조회
+    @Transactional
+    public List<BoardResponse> getPopularBoards(){
+        List<Board> popularBoards=boardRepository.findPopularBoards();
+        return popularBoards.stream().map(BoardResponse::new).toList();
+    }
+
 }

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -21,6 +21,7 @@ public enum SuccessCode {
     BOARD_DETAIL_FETCHED(HttpStatus.OK, "게시글을 단일 조회했습니다."),
     BOARD_ALL_FETCHED(HttpStatus.OK, "모든 게시글 목록을 조회했습니다."),
     MY_BOARD_LIST_FETCHED(HttpStatus.OK, "내가 작성한 게시글 목록을 조회했습니다."),
+    POPULAR_BOARD_ALL_FETCHED(HttpStatus.OK, "모든 인기 게시글을 조회했습니다."),
 
     //comment
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),


### PR DESCRIPTION
# 설명
- 인기 게시글 목록 조회 기능 구현

# 작업내용
- 인기 게시글을 전체 조회하는 기능 구현
- 게시글의 좋아요 수, 조회수 의 합이 30 이상인 경우를 인기 게시글로 간주
-  BoardRepository에 인기 게시글 조회용 JPQL 쿼리 메서드 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve a list of popular board posts.
  * Popular boards are determined by their combined view and love counts.
  * Responses for popular board retrieval now include a dedicated success message.

* **Chores**
  * Removed an unused import from the authentication controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->