### PR TITLE
[Feat] 내가 쓴 댓글 조회 및 댓글 삭제 API 구현

### DIFF
--- a/src/main/java/backend/hiteen/board/entity/Board.java
+++ b/src/main/java/backend/hiteen/board/entity/Board.java
@@ -45,7 +45,7 @@ public class Board extends BaseTimeEntity {
     @Column(nullable = false)
     private Long viewCount = 0L;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/backend/hiteen/comment/controller/CommentController.java
+++ b/src/main/java/backend/hiteen/comment/controller/CommentController.java
@@ -53,7 +53,7 @@ public class CommentController {
                 principal.getId(),
                 commentId,
                 request.getContent()
-                );
+        );
 
         return ResponseEntity
                 .status(SuccessCode.REPLY_CREATED.getStatus())
@@ -98,5 +98,17 @@ public class CommentController {
         return ResponseEntity
                 .status(code.getStatus())
                 .body(ApiResponse.success(code, response));
+    }
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글/대댓글 삭제", description = "댓글/ 대댓글을 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(principal.getId(), commentId);
+        return ResponseEntity
+                .status(SuccessCode.COMMENT_DELETED.getStatus())
+                .body(ApiResponse.success(SuccessCode.COMMENT_DELETED, null));
     }
 }

--- a/src/main/java/backend/hiteen/comment/controller/CommentController.java
+++ b/src/main/java/backend/hiteen/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import backend.hiteen.comment.dto.request.CommentRequestDto;
 import backend.hiteen.comment.dto.request.ReplyCommentRequestDto;
 import backend.hiteen.comment.dto.response.CommentLikeResponse;
 import backend.hiteen.comment.dto.response.CommentResponseDto;
+import backend.hiteen.comment.dto.response.MyCommentResponse;
+import backend.hiteen.comment.dto.response.ReplyCommentResponseDto;
 import backend.hiteen.comment.service.CommentService;
 import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.SuccessCode;
@@ -43,14 +45,14 @@ public class CommentController {
 
     @PostMapping("/{commentId}/replies")
     @Operation(summary = "대댓글 작성", description = "특정 댓글에 대한 대댓글을 작성합니다.")
-    public ResponseEntity<ApiResponse<CommentResponseDto>> addReplyComment(
+    public ResponseEntity<ApiResponse<ReplyCommentResponseDto>> addReplyComment(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long commentId,
             @RequestBody ReplyCommentRequestDto request) {
-        CommentResponseDto response = commentService.addReplyComment
-                (principal.getId(),
-                 commentId,
-                 request.getContent()
+        ReplyCommentResponseDto response = commentService.addReplyComment(
+                principal.getId(),
+                commentId,
+                request.getContent()
                 );
 
         return ResponseEntity
@@ -66,6 +68,17 @@ public class CommentController {
         Long memberId = principal != null ? principal.getId() : null;
         List<CommentResponseDto> comments = commentService.getComments(boardId, memberId);
 
+        return ResponseEntity
+                .status(SuccessCode.COMMENT_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.COMMENT_FETCHED, comments));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내가 쓴 댓글/대댓글 조회", description = "내가 쓴 댓글/대댓글과 게시글 정보를 조회합니다")
+    public ResponseEntity<ApiResponse<List<MyCommentResponse>>> getMyComments(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        List<MyCommentResponse> comments = commentService.getMyComments(principal.getId());
         return ResponseEntity
                 .status(SuccessCode.COMMENT_FETCHED.getStatus())
                 .body(ApiResponse.success(SuccessCode.COMMENT_FETCHED, comments));

--- a/src/main/java/backend/hiteen/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/backend/hiteen/comment/dto/response/CommentResponseDto.java
@@ -24,6 +24,7 @@ public class CommentResponseDto {
 
     private int likeCount;
     private boolean likedByMe;
+    private boolean idBoardWriter;
 
     //대댓글
     @Schema(description = "해당 댓글에 달린 대댓글 목록")

--- a/src/main/java/backend/hiteen/comment/dto/response/MyCommentResponse.java
+++ b/src/main/java/backend/hiteen/comment/dto/response/MyCommentResponse.java
@@ -1,0 +1,17 @@
+package backend.hiteen.comment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MyCommentResponse {
+    private Long boardId;
+    private String boardTitle;
+    private Long commentId;
+    private String content;
+    private boolean isReply;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/backend/hiteen/comment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/backend/hiteen/comment/dto/response/ReplyCommentResponseDto.java
@@ -23,5 +23,6 @@ public class ReplyCommentResponseDto {
 
     private int likeCount;
     private boolean likedByMe;
+    private boolean idBoardWriter;
 
 }

--- a/src/main/java/backend/hiteen/comment/exception/CommentNotOwnerException.java
+++ b/src/main/java/backend/hiteen/comment/exception/CommentNotOwnerException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.comment.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class CommentNotOwnerException extends BusinessException {
+    public CommentNotOwnerException() {
+        super(ErrorCode.COMMENT_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
+++ b/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package backend.hiteen.comment.repository;
 
 import backend.hiteen.comment.entity.Comment;
+import backend.hiteen.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,5 +20,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findRootsByBoardId(@Param("boardId") Long boardId);
 
     Optional<Comment> findByBoardIdAndMemberId(Long boardId, Long memberId);
+
+    List<Comment> findAllByMember(Member member);
 
 }

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import backend.hiteen.board.exception.BoardNotFoundException;
 import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.comment.dto.response.CommentLikeResponse;
 import backend.hiteen.comment.dto.response.CommentResponseDto;
+import backend.hiteen.comment.dto.response.MyCommentResponse;
 import backend.hiteen.comment.dto.response.ReplyCommentResponseDto;
 import backend.hiteen.comment.entity.Comment;
 import backend.hiteen.comment.entity.CommentLike;
@@ -48,6 +49,8 @@ public class CommentService {
                 .build();
         commentRepository.save(comment);
 
+        boolean isBoardWriter = comment.getMember().getId().equals(board.getMember().getId());
+
         return new CommentResponseDto(
                 comment.getId(),
                 comment.getContent(),
@@ -55,12 +58,13 @@ public class CommentService {
                 comment.getCreatedAt(),
                 0,
                 false,
+                isBoardWriter,
                 List.of()
         );
     }
 
     @Transactional
-    public CommentResponseDto addReplyComment(Long memberId,Long parentCommentId, String content) {
+    public ReplyCommentResponseDto addReplyComment(Long memberId,Long parentCommentId, String content) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
         Comment parentComment = commentRepository.findById(parentCommentId)
@@ -79,14 +83,16 @@ public class CommentService {
 
         commentRepository.save(replycomment);
 
-        return new CommentResponseDto(
+        boolean replyIsBoardWriter = replycomment.getMember().getId().equals(board.getMember().getId());
+
+        return new ReplyCommentResponseDto(
                 replycomment.getId(),
                 replycomment.getContent(),
                 replycomment.getAnonymousNumber(),
                 replycomment.getCreatedAt(),
                 0,
                 false,
-                List.of()
+                replyIsBoardWriter
         );
     }
 
@@ -108,6 +114,25 @@ public class CommentService {
 
         return topLevelComments.stream()
                 .map(c -> covertToDto(c, member))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyCommentResponse> getMyComments(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        List<Comment> myComments = commentRepository.findAllByMember(member);
+
+        return myComments.stream()
+                .map(comment -> new MyCommentResponse(
+                        comment.getBoard().getId(),
+                        comment.getBoard().getTitle(),
+                        comment.getId(),
+                        comment.getContent(),
+                        comment.getParentComment() != null,
+                        comment.getCreatedAt()
+                ))
                 .toList();
     }
 
@@ -138,15 +163,14 @@ public class CommentService {
 
     private CommentResponseDto covertToDto(Comment comment, Member member) {
         int likeCount = commentLikeRepository.countByComment(comment);
-        boolean likedByMe = false;
-        if (member != null) {
-            likedByMe = commentLikeRepository.findByCommentAndMember(comment, member).isPresent();
-        }
+        boolean likedByMe = member != null && commentLikeRepository.findByCommentAndMember(comment, member).isPresent();
+        boolean isBoardWriter = comment.getMember().getId().equals(comment.getBoard().getMember().getId());
 
         List<ReplyCommentResponseDto> replies = comment.getChildrenComment().stream()
                 .map(child -> {
                     int replyLikeCount = commentLikeRepository.countByComment(child);
                     boolean replyLikedByMe = member != null && commentLikeRepository.findByCommentAndMember(child, member).isPresent();
+                    boolean replyIsBoardWriter = child.getMember().getId().equals(child.getBoard().getMember().getId());
 
                     return new ReplyCommentResponseDto(
                             child.getId(),
@@ -154,7 +178,8 @@ public class CommentService {
                             child.getAnonymousNumber(),
                             child.getCreatedAt(),
                             replyLikeCount,
-                            replyLikedByMe
+                            replyLikedByMe,
+                            replyIsBoardWriter
                     );
                 })
                 .toList();
@@ -166,6 +191,7 @@ public class CommentService {
                 comment.getCreatedAt(),
                 likeCount,
                 likedByMe,
+                isBoardWriter,
                 replies
                 );
     }

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import backend.hiteen.comment.dto.response.ReplyCommentResponseDto;
 import backend.hiteen.comment.entity.Comment;
 import backend.hiteen.comment.entity.CommentLike;
 import backend.hiteen.comment.exception.CommentNotFoundException;
+import backend.hiteen.comment.exception.CommentNotOwnerException;
 import backend.hiteen.comment.repository.CommentLikeRepository;
 import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.member.entity.Member;
@@ -159,6 +160,18 @@ public class CommentService {
 
         int likeCount = commentLikeRepository.countByComment(comment);
         return new CommentLikeResponse(likeCount, liked);
+    }
+
+    @Transactional
+    public void deleteComment(Long memberId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new CommentNotOwnerException();
+        }
+
+        commentRepository.delete(comment);
     }
 
     private CommentResponseDto covertToDto(Comment comment, Member member) {

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 
     //comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
+    COMMENT_PERMISSION_DENIED(HttpStatus.FORBIDDEN,"댓글에 대한 권한이 없습니다."),
 
     //love
     LOVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -28,6 +28,7 @@ public enum SuccessCode {
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),
     REPLY_CREATED(HttpStatus.CREATED,"대댓글이 등록되었습니다."),
     COMMENT_FETCHED(HttpStatus.OK, "댓글 목록을 불러왔습니다."),
+    COMMENT_DELETED(HttpStatus.OK, "댓글이 삭제되었습니다."),
     COMMENT_LIKED_CREATED(HttpStatus.CREATED, "댓글 좋아요 되었습니다."),
     COMMENT_LIKED_DELETED(HttpStatus.OK, "댓글 좋아요가 취소되었습니다."),
 


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->

- 내가 쓴 댓글(및 대댓글) 조회 API 구현
- 댓글/대댓글 삭제 API 구현


## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 로그인한 사용자의 댓글/대댓글 전체 조회 API 추가
- 작업 2 본인 작성 댓글/대댓글만 삭제 가능하도록 권한 체크 -> 댓글 및 대댓글 삭제 API 추가

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1 삭제 API는 본인 댓글/대댓글만 삭제할 수 있습니다.
- 공유 사항 2 내 댓글/대댓글 조회 시 프론트에서 isReply 필드로 구분해주시면 됩니다. 댓글 작성시 게시글 작성자 여부도 추가했습니다.

 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint for users to retrieve their own comments and replies, including related post information.
  * Introduced API endpoint allowing users to delete their own comments or replies.
  * Comment and reply responses now indicate if the author is the board writer.
  * Added explicit error and success messages for comment permission denial and successful deletion.

* **Bug Fixes**
  * Improved comment ownership validation for deletion actions.

* **Refactor**
  * Enhanced response types for reply comments to provide more specific information.
  * Updated comment fetching strategy for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->