### PR TITLE
[Feat/#82]: 게시글 삭제 API 구현

### DIFF
--- a/src/main/java/backend/hiteen/auth/dto/response/TokenResponse.java
+++ b/src/main/java/backend/hiteen/auth/dto/response/TokenResponse.java
@@ -2,7 +2,6 @@ package backend.hiteen.auth.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -68,6 +67,12 @@ public class BoardController {
     public ResponseEntity<ApiResponse<List<BoardResponse>>> searchBoards(@RequestParam("keyword") String keyword){
         List<BoardResponse> responses=boardService.searchBoards(keyword);
         return ResponseEntity.status(SuccessCode.SEARCHED_BOARD_LIST_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.SEARCHED_BOARD_LIST_FETCHED, responses));
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ApiResponse<Void>> deleteBoard(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long boardId){
+        boardService.deleteBoard(principal.getUsername(),boardId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.BOARD_DELETED));
     }
 
 }

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -9,7 +9,6 @@ import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.converters.models.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -83,6 +82,19 @@ public class BoardService {
 
         List<Board> boards=boardRepository.searchByKeyword(keyword);
         return boards.stream().map(BoardResponse::new).toList();
+    }
+
+    //게시글 삭제
+    public void deleteBoard(String email, Long boardId){
+        Member member=memberRepository.findByEmail(email).orElseThrow(()-> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Board board=boardRepository.findById(boardId).orElseThrow(()->new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+
+        if(!board.getMember().equals(member)){
+            throw new BusinessException(ErrorCode.NO_PERMISSION_TO_DELETE_BOARD);
+        }
+
+        boardRepository.delete(board);
     }
 
 }

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
     BOARD_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 작성에 실패했습니다."),
     KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요."),
+    NO_PERMISSION_TO_DELETE_BOARD(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
 
     //comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -23,6 +23,7 @@ public enum SuccessCode {
     MY_BOARD_LIST_FETCHED(HttpStatus.OK, "내가 작성한 게시글 목록을 조회했습니다."),
     POPULAR_BOARD_ALL_FETCHED(HttpStatus.OK, "모든 인기 게시글을 조회했습니다."),
     SEARCHED_BOARD_LIST_FETCHED(HttpStatus.OK, "검색된 게시글 목록을 조회했습니다."),
+    BOARD_DELETED(HttpStatus.OK, "게시글이 성공적으로 삭제되었습니다."),
 
     //comment
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),

--- a/src/main/java/backend/hiteen/member/controller/MemberController.java
+++ b/src/main/java/backend/hiteen/member/controller/MemberController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 게시글 삭제 API 구현
## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 게시글 삭제 기능 구현
- 도메인마다 불필요한 import문 삭제

## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to delete boards through a new endpoint.
  * Introduced clear success and error messages for board deletion actions.

* **Style**
  * Removed unused import statements from various files to improve code cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->