### PR TITLE
fix : 익명 쪽지 기능 예외처리 추가 및 강화

### DIFF
--- a/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
+++ b/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
@@ -23,4 +23,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByMember(Member member);
 
+    Optional<Comment> findByBoardIdAndAnonymousNumber(Long boardId, Integer anonymousNumber);
+
+
 }

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -36,6 +36,10 @@ public enum ErrorCode {
     //message
     MESSAGE_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "쪽지방을 찾을 수 없습니다."),
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "쪽지를 찾을 수 없습니다."),
+    CANNOT_SEND_MESSAGE_TO_SELF(HttpStatus.BAD_REQUEST, "자기 자신에게 쪽지를 보낼 수 없습니다."),
+    MESSAGE_TARGET_NOT_SPECIFIED(HttpStatus.BAD_REQUEST, "쪽지 받을 대상을 지정해 주세요."),
+    COMMENT_ANONYMOUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 익명번호의 댓글이 존재하지 않습니다."),
+    INVALID_MESSAGE_TARGET(HttpStatus.BAD_REQUEST, "쪽지 대상은 게시글 작성자 또는 특정 댓글러 중 하나만 지정할 수 있습니다."),
 
     //Meal
     MEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "급식 정보를 찾을 수 없습니다."),

--- a/src/main/java/backend/hiteen/message/controller/MessageController.java
+++ b/src/main/java/backend/hiteen/message/controller/MessageController.java
@@ -1,15 +1,18 @@
 package backend.hiteen.message.controller;
 
+import backend.hiteen.auth.security.CustomUserPrincipal;
 import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.message.dto.request.MessageRequest;
 import backend.hiteen.message.dto.request.MessageRoomRequest;
 import backend.hiteen.message.dto.response.MessageResponse;
+import backend.hiteen.message.entity.Message;
 import backend.hiteen.message.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -26,15 +29,13 @@ public class MessageController {
     @PostMapping("/send")
     @Operation(summary = "쪽지 보내기", description = "새 쪽지를 보냅니다.")
     public ResponseEntity<ApiResponse<MessageResponse>> sendMessage(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody MessageRequest request) {
-        MessageResponse response = messageService.toDto(
-                messageService.sendMessage(
-                        request.getBoardId(),
-                        request.getSenderId(),
-                        request.getReceiverId(),
-                        request.getContent()
-                )
-        );
+
+        Long memberId = principal.getId();
+        Message message = messageService.sendMessage(request, memberId);
+        MessageResponse response = messageService.toDto(message, memberId);
+
         return ResponseEntity
                 .status(SuccessCode.MESSAGE_SENT.getStatus())
                 .body(ApiResponse.success(SuccessCode.MESSAGE_SENT, response));
@@ -43,15 +44,13 @@ public class MessageController {
     @PostMapping("/room/{roomId}/send")
     @Operation(summary = "쪽지방 내 메시지 전송", description = "기존 쪽지방에 쪽지를 전송합니다.")
     public ResponseEntity<ApiResponse<MessageResponse>> sendMessageInRoom(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long roomId,
             @RequestBody MessageRoomRequest request) {
-        MessageResponse response = messageService.toDto(
-                messageService.sendMessageInRoom(
-                        roomId,
-                        request.getSenderId(),
-                        request.getContent()
-                )
-        );
+        Long memberId = principal.getId();
+        Message message = messageService.sendMessageInRoom(roomId, memberId, request.getContent());
+        MessageResponse response = messageService.toDto(message, memberId);
+
         return ResponseEntity
                 .status(SuccessCode.MESSAGE_SENT_IN_ROOM.getStatus())
                 .body(ApiResponse.success(SuccessCode.MESSAGE_SENT_IN_ROOM, response));
@@ -60,9 +59,11 @@ public class MessageController {
     @GetMapping("/room/{roomId}")
     @Operation(summary = "쪽지방 메시지 조회", description = "특정 쪽지방의 전체 메시지를 조회합니다.")
     public ResponseEntity<ApiResponse<List<MessageResponse>>> getMessages(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long roomId) {
+        Long memberId = principal.getId();
         List<MessageResponse> responseList = messageService.getMessages(roomId).stream()
-                .map(messageService::toDto)
+                .map(m -> messageService.toDto(m, memberId))
                 .toList();
         return ResponseEntity
                 .ok(ApiResponse.success(SuccessCode.MESSAGES_FETCHED, responseList));
@@ -71,8 +72,10 @@ public class MessageController {
     @GetMapping("/room/{roomId}/poll")
     @Operation(summary = "롱폴링 메시지 수신", description = "새 메시지가 올 때까지 대기하여 전달합니다.")
     public DeferredResult<ResponseEntity<ApiResponse<List<MessageResponse>>>> pollMessages(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long roomId,
             @RequestParam(defaultValue = "0") Long lastMessageId) {
-        return messageService.pollMessages(roomId, lastMessageId);
+        Long memberId = principal.getId();
+        return messageService.pollMessages(roomId, lastMessageId, memberId);
     }
 }

--- a/src/main/java/backend/hiteen/message/dto/request/MessageRequest.java
+++ b/src/main/java/backend/hiteen/message/dto/request/MessageRequest.java
@@ -11,13 +11,11 @@ public class MessageRequest {
     @Schema(description = "게시글 ID", example = "1")
     private Long boardId;
 
-    @NotNull
-    @Schema(description = "발신자 ID", example = "2")
-    private Long senderId;
+    @Schema(description = "받는 사람이 게시글 작성자인 경우 true", example = "true")
+    private Boolean isBoardWriter;
 
-    @NotNull
-    @Schema(description = "수신자 ID", example = "3")
-    private Long receiverId;
+    @Schema(description = "익명 번호(댓글러에게 쪽지 보낼 때)", example = "3")
+    private Integer anonymousNumber;
 
     @NotNull
     @Schema(description = "쪽지 내용", example = "안녕하세요!")

--- a/src/main/java/backend/hiteen/message/dto/request/MessageRoomRequest.java
+++ b/src/main/java/backend/hiteen/message/dto/request/MessageRoomRequest.java
@@ -5,9 +5,6 @@ import lombok.Data;
 
 @Data
 public class MessageRoomRequest {
-    @Schema(description = "발신자 ID", example = "2")
-    private Long senderId;
-
     @Schema(description = "쪽지 내용", example = "안녕하세요?")
     private String content;
 }

--- a/src/main/java/backend/hiteen/message/dto/response/MessageResponse.java
+++ b/src/main/java/backend/hiteen/message/dto/response/MessageResponse.java
@@ -13,20 +13,19 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class MessageResponse {
 
-    @Schema(description = "메시지 ID", example = "10")
+    @Schema(description = "메시지 ID")
     private Long messageId;
 
-    @Schema(description = "쪽지방 ID", example = "5")
+    @Schema(description = "쪽지방 ID")
     private Long roomId;
 
-    @Schema(description = "발신자 ID", example = "2")
-    private Long senderId;
-
-    @Schema(description = "쪽지 내용", example = "반갑습니다!")
+    @Schema(description = "쪽지 내용")
     private String content;
 
     private LocalDateTime createdAt;
 
-    @Schema(description = "작성자", example = "작성자")
+    @Schema(description = "작성자/익명N/익명")
     private String chatNickname;
+
+    private Boolean isMine;
 }

--- a/src/main/java/backend/hiteen/message/entity/Message.java
+++ b/src/main/java/backend/hiteen/message/entity/Message.java
@@ -1,20 +1,19 @@
 package backend.hiteen.message.entity;
 
 
+import backend.hiteen.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Message {
+public class Message extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,5 +25,4 @@ public class Message {
 
     private Long senderId;
     private String content;
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/backend/hiteen/message/entity/MessageRoom.java
+++ b/src/main/java/backend/hiteen/message/entity/MessageRoom.java
@@ -2,6 +2,7 @@ package backend.hiteen.message.entity;
 
 
 import backend.hiteen.board.entity.Board;
+import backend.hiteen.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MessageRoom {
+public class MessageRoom extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -28,5 +29,4 @@ public class MessageRoom {
 
     private Long receiverId;
 
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/backend/hiteen/message/exception/CannotSendMessageToSelfException.java
+++ b/src/main/java/backend/hiteen/message/exception/CannotSendMessageToSelfException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.message.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class CannotSendMessageToSelfException extends BusinessException {
+    public CannotSendMessageToSelfException() {
+        super(ErrorCode.CANNOT_SEND_MESSAGE_TO_SELF);
+    }
+}

--- a/src/main/java/backend/hiteen/message/exception/CommentAnonymousNotFoundException.java
+++ b/src/main/java/backend/hiteen/message/exception/CommentAnonymousNotFoundException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.message.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class CommentAnonymousNotFoundException extends BusinessException {
+    public CommentAnonymousNotFoundException() {
+        super(ErrorCode.COMMENT_ANONYMOUS_NOT_FOUND);
+    }
+}

--- a/src/main/java/backend/hiteen/message/exception/InvalidMessageTargetException.java
+++ b/src/main/java/backend/hiteen/message/exception/InvalidMessageTargetException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.message.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class InvalidMessageTargetException extends BusinessException {
+    public InvalidMessageTargetException() {
+        super(ErrorCode.INVALID_MESSAGE_TARGET);
+    }
+}

--- a/src/main/java/backend/hiteen/message/exception/MessageTargetNotSpecifiedException.java
+++ b/src/main/java/backend/hiteen/message/exception/MessageTargetNotSpecifiedException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.message.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class MessageTargetNotSpecifiedException extends BusinessException {
+    public MessageTargetNotSpecifiedException() {
+        super(ErrorCode.MESSAGE_TARGET_NOT_SPECIFIED);
+    }
+}

--- a/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
@@ -3,9 +3,19 @@ package backend.hiteen.message.repository;
 
 import backend.hiteen.message.entity.MessageRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MessageRoomRepository extends JpaRepository<MessageRoom, Long> {
-    Optional<MessageRoom> findMessageRoomByBoardIdAndSenderIdAndReceiverId(Long boardId, Long senderId, Long receiverId);
+
+    @Query("select mr from MessageRoom mr " +
+            "where mr.board.id = :boardId " +
+            "and ((mr.senderId = :id1 and mr.receiverId = :id2) " +
+            "or (mr.senderId = :id2 and mr.receiverId = :id1))")
+    Optional<MessageRoom> findByBoardIdAndParticipants(
+            @Param("boardId") Long boardId,
+            @Param("id1") Long id1,
+            @Param("id2") Long id2);
 }

--- a/src/main/java/backend/hiteen/message/service/MessageService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageService.java
@@ -8,10 +8,11 @@ import backend.hiteen.comment.entity.Comment;
 import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.SuccessCode;
+import backend.hiteen.message.dto.request.MessageRequest;
 import backend.hiteen.message.dto.response.MessageResponse;
 import backend.hiteen.message.entity.Message;
 import backend.hiteen.message.entity.MessageRoom;
-import backend.hiteen.message.exception.MessageRoomNotFoundException;
+import backend.hiteen.message.exception.*;
 import backend.hiteen.message.repository.MessageRepository;
 import backend.hiteen.message.repository.MessageRoomRepository;
 import lombok.AllArgsConstructor;
@@ -20,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.request.async.DeferredResult;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,43 +33,74 @@ public class MessageService {
     private final MessageRoomRepository messageRoomRepository;
 
 
-    public MessageResponse toDto(Message message) {
+    public MessageResponse toDto(Message message, Long memberId) {
         return new MessageResponse(
                 message.getId(),
                 message.getMessageRoom().getId(),
-                message.getSenderId(),
                 message.getContent(),
                 message.getCreatedAt(),
-                computeDisplayName(message)
+                computeDisplayName(message),
+                message.getSenderId().equals(memberId)
         );
     }
 
     // 대화 방 생성 및 메시지 전송
     @Transactional
-    public Message sendMessage(Long boardId, Long senderId, Long receiverId, String content) {
-
-        Board board = boardRepository.findById(boardId)
+    public Message sendMessage(MessageRequest request, Long memberId) {
+        Board board = boardRepository.findById(request.getBoardId())
                 .orElseThrow(BoardNotFoundException::new);
 
-        Optional<MessageRoom> optionalRoom = messageRoomRepository.findMessageRoomByBoardIdAndSenderIdAndReceiverId(boardId, senderId, receiverId);
-        MessageRoom messageRoom = optionalRoom.orElse(null);
+        Long receiverId;
 
+        //둘 다 동시에 값 들어오지 않게
+        if (Boolean.TRUE.equals(request.getIsBoardWriter()) && request.getAnonymousNumber() != null) {
+            throw new InvalidMessageTargetException();
+        }
+
+        //작성자에게 쪽지보냄
+        if (Boolean.TRUE.equals(request.getIsBoardWriter())) {
+            receiverId = board.getMember().getId();
+
+            if (receiverId.equals(memberId)) {
+                throw new CannotSendMessageToSelfException();
+            }
+            //익명 댓글러에게 쪽지보냄
+        } else if (request.getAnonymousNumber() != null) {
+            Comment comment = commentRepository.findByBoardIdAndAnonymousNumber(
+                    request.getBoardId(), request.getAnonymousNumber()
+            ).orElseThrow(CommentAnonymousNotFoundException::new);
+
+            receiverId = comment.getMember().getId();
+
+            if (receiverId.equals(memberId)) {
+                throw new CannotSendMessageToSelfException();
+            }
+
+        } else {
+            throw new MessageTargetNotSpecifiedException();
+        }
+
+        Optional<MessageRoom> optionalRoom =
+                messageRoomRepository.findByBoardIdAndParticipants(
+                        request.getBoardId(), memberId, receiverId
+                );
+
+        MessageRoom messageRoom = optionalRoom.orElse(null);
 
         if (messageRoom == null) {
             messageRoom = MessageRoom.builder()
                     .board(board)
-                    .senderId(senderId)
+                    .senderId(memberId)
                     .receiverId(receiverId)
-                    .createdAt(LocalDateTime.now())
                     .build();
+
             messageRoom = messageRoomRepository.save(messageRoom);
         }
 
         Message message = Message.builder()
                 .messageRoom(messageRoom)
-                .senderId(senderId)
-                .content(content)
-                .createdAt(LocalDateTime.now())
+                .senderId(memberId)
+                .content(request.getContent())
                 .build();
 
         return messageRepository.save(message);
@@ -78,14 +109,17 @@ public class MessageService {
     // 대화 방 내 메세지 전송
 
     @Transactional
-    public Message sendMessageInRoom(Long roomId, Long senderId, String content) {
+    public Message sendMessageInRoom(Long roomId, Long memberId, String content) {
         MessageRoom room = messageRoomRepository.findById(roomId)
                 .orElseThrow(MessageRoomNotFoundException::new);
+
+        if (!memberId.equals(room.getSenderId()) && !memberId.equals(room.getReceiverId())) {
+            throw new IllegalArgumentException("이 쪽지방에 메시지를 보낼 권한이 없습니다.");
+        }
         Message message = Message.builder()
                 .messageRoom(room)
-                .senderId(senderId)
+                .senderId(memberId)
                 .content(content)
-                .createdAt(LocalDateTime.now())
                 .build();
 
         return messageRepository.save(message);
@@ -105,14 +139,14 @@ public class MessageService {
     }
 
     //롱폴링
-    public DeferredResult<ResponseEntity<ApiResponse<List<MessageResponse>>>> pollMessages(Long roomId, Long lastMessageId) {
+    public DeferredResult<ResponseEntity<ApiResponse<List<MessageResponse>>>> pollMessages(Long roomId, Long lastMessageId, Long memberId) {
         long timeout = 30_000L;
         DeferredResult<ResponseEntity<ApiResponse<List<MessageResponse>>>> result =
                 new DeferredResult<>(timeout);
 
         new Thread(() -> {
             List<MessageResponse> body = getMessageAfter(roomId, lastMessageId).stream()
-                    .map(this::toDto)
+                    .map(m -> toDto(m, memberId))
                     .toList();
             ResponseEntity<ApiResponse<List<MessageResponse>>> response =
                     ResponseEntity


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 게시글 작성자&댓글러에게 쪽지 보내기 내부 로직 수정
- 예외 처리 및 입력 값에 따른 유효성 검증

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 게시글 작성자 또는 익명 댓글러 중 한명에게만 쪽지 보낼 수 있도록 예외 처리
- 작업 2 댓글 미존재, 게시글 미존재시 예외처리
- 작업 3 양방향 중복 쪽지방 방지 쿼리문 작성

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1 기존 기능에서 달라진게 많아 body 값 다시 한 번 확인해주세요
- 공유 사항 2
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new error messages for messaging and comment-related actions, including cases such as self-messaging, unspecified message targets, and invalid message recipients.
  * Introduced clearer error handling for messaging to anonymous commenters.

* **Improvements**
  * Enhanced message sending and retrieval to use authenticated user identity, improving security and consistency.
  * Simplified message request and response formats for clarity, including new fields to indicate message ownership and recipient type.
  * Improved validation and authorization checks when sending messages and accessing message rooms.

* **Bug Fixes**
  * Fixed issues where users could attempt to send messages to themselves or to invalid targets.

* **Refactor**
  * Streamlined timestamp management for messages and message rooms.
  * Updated internal logic for message room lookups to be more robust and order-agnostic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->