### PR TITLE
feat : 내가 참여한 쪽지방 리스트 구현 및 읽은 갯수처리

### DIFF
--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -49,7 +49,8 @@ public enum SuccessCode {
     MESSAGE_SENT(HttpStatus.CREATED, "쪽지를 보냈습니다."),
     MESSAGE_SENT_IN_ROOM(HttpStatus.CREATED, "쪽지방에 메시지를 보냈습니다."),
     MESSAGES_FETCHED(HttpStatus.OK, "쪽지 목록을 조회했습니다."),
-    MESSAGE_POLLED(HttpStatus.OK, "롱폴링으로 새 메시지를 조회했습니다()"),
+    MESSAGE_POLLED(HttpStatus.OK, "롱폴링으로 새 메시지를 조회했습니다."),
+    MESSAGE_ROOMS_FETCHED(HttpStatus.OK, "쪽지방 목록 조회했습니다."),
 
     //Meal
     MEAL_FETCHED(HttpStatus.OK, "급식 조회했습니다."),

--- a/src/main/java/backend/hiteen/message/controller/MessageController.java
+++ b/src/main/java/backend/hiteen/message/controller/MessageController.java
@@ -6,6 +6,7 @@ import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.message.dto.request.MessageRequest;
 import backend.hiteen.message.dto.request.MessageRoomRequest;
 import backend.hiteen.message.dto.response.MessageResponse;
+import backend.hiteen.message.dto.response.MessageRoomListResponse;
 import backend.hiteen.message.entity.Message;
 import backend.hiteen.message.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,12 +63,24 @@ public class MessageController {
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long roomId) {
         Long memberId = principal.getId();
-        List<MessageResponse> responseList = messageService.getMessages(roomId).stream()
-                .map(m -> messageService.toDto(m, memberId))
-                .toList();
+        List<MessageResponse> responseList = messageService.getMessages(roomId, memberId);
         return ResponseEntity
-                .ok(ApiResponse.success(SuccessCode.MESSAGES_FETCHED, responseList));
+                .status(SuccessCode.MESSAGES_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.MESSAGES_FETCHED, responseList));
     }
+
+        @GetMapping("/rooms")
+    @Operation(summary = "참여한 쪽지방 목록 조회", description = "사용자가 참여한 모든 쪽지방 목록을 최신 메세지 기준으로 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MessageRoomListResponse>>> getMyMessageRooms(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        Long memberId = principal.getId();
+        List<MessageRoomListResponse> rooms = messageService.getMyMessageRooms(memberId);
+        return ResponseEntity
+                .status(SuccessCode.MESSAGE_ROOMS_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.MESSAGE_ROOMS_FETCHED, rooms));
+    }
+
 
     @GetMapping("/room/{roomId}/poll")
     @Operation(summary = "롱폴링 메시지 수신", description = "새 메시지가 올 때까지 대기하여 전달합니다.")

--- a/src/main/java/backend/hiteen/message/dto/response/MessageRoomListResponse.java
+++ b/src/main/java/backend/hiteen/message/dto/response/MessageRoomListResponse.java
@@ -1,0 +1,19 @@
+package backend.hiteen.message.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class MessageRoomListResponse {
+    private Long roomId;
+    private Long boardId;
+    private String boardTitle;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+    private String lastMessageNickname;
+    private Integer unreadCount;
+    private String chatNickname; //(익명n,작성자,익명)
+}

--- a/src/main/java/backend/hiteen/message/entity/Message.java
+++ b/src/main/java/backend/hiteen/message/entity/Message.java
@@ -3,13 +3,11 @@ package backend.hiteen.message.entity;
 
 import backend.hiteen.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,5 +22,9 @@ public class Message extends BaseTimeEntity {
     private MessageRoom messageRoom;
 
     private Long senderId;
+    private Long receiverId;
     private String content;
+
+    @Column(name = "is_read")
+    private boolean isRead = false;
 }

--- a/src/main/java/backend/hiteen/message/repository/MessageRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRepository.java
@@ -5,9 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findByMessageRoomIdOrderByCreatedAtAsc(Long messageRoomId);
+
+    Optional<Message> findTopByMessageRoomIdOrderByCreatedAtDesc(Long messageRoomId);
+
+    int countByMessageRoomIdAndReceiverIdAndIsReadFalse(Long roomId, Long memberId);
+    List<Message> findByMessageRoomIdAndReceiverIdAndIsReadFalse(Long roomId, Long receiverId);
+
 }
+

--- a/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
@@ -6,16 +6,27 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MessageRoomRepository extends JpaRepository<MessageRoom, Long> {
 
-    @Query("select mr from MessageRoom mr " +
-            "where mr.board.id = :boardId " +
-            "and ((mr.senderId = :id1 and mr.receiverId = :id2) " +
-            "or (mr.senderId = :id2 and mr.receiverId = :id1))")
+    @Query("""
+            select mr from MessageRoom mr
+            where mr.board.id = :boardId
+            and ((mr.senderId = :id1 and mr.receiverId = :id2)
+            or (mr.senderId = :id2 and mr.receiverId = :id1))
+            """)
     Optional<MessageRoom> findByBoardIdAndParticipants(
             @Param("boardId") Long boardId,
             @Param("id1") Long id1,
             @Param("id2") Long id2);
+
+    @Query("""
+                    select mr
+                    from MessageRoom mr
+                    where mr.senderId = :memberId or mr.receiverId = :memberId
+                    order by (select max(m.createdAt) from Message m where m.messageRoom = mr) desc
+            """)
+    List<MessageRoom> findAllByMember(@Param("memberId") Long memberId);
 }

--- a/src/main/java/backend/hiteen/message/service/MessageService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageService.java
@@ -10,6 +10,7 @@ import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.SuccessCode;
 import backend.hiteen.message.dto.request.MessageRequest;
 import backend.hiteen.message.dto.response.MessageResponse;
+import backend.hiteen.message.dto.response.MessageRoomListResponse;
 import backend.hiteen.message.entity.Message;
 import backend.hiteen.message.entity.MessageRoom;
 import backend.hiteen.message.exception.*;
@@ -21,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.request.async.DeferredResult;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -127,8 +130,14 @@ public class MessageService {
 
 
     //특정 방 대화 전체 조회
-    public List<Message> getMessages(Long roomId) {
-        return messageRepository.findByMessageRoomIdOrderByCreatedAtAsc(roomId);
+    @Transactional
+    public List<MessageResponse> getMessages(Long roomId, Long memberId) {
+        readAllUnreadMessages(roomId, memberId);
+
+        List<Message> messages = messageRepository.findByMessageRoomIdOrderByCreatedAtAsc(roomId);
+        return messages.stream()
+                .map(m -> toDto(m, memberId))
+                .toList();
     }
 
     public List<Message> getMessageAfter(Long roomId, Long lastMessageId) {
@@ -136,6 +145,39 @@ public class MessageService {
                 .stream()
                 .filter(m -> m.getId() > lastMessageId)
                 .toList();
+    }
+
+    public List<MessageRoomListResponse> getMyMessageRooms(Long memberId) {
+        List<MessageRoom> rooms = messageRoomRepository.findAllByMember(memberId);
+
+        List<MessageRoomListResponse> result = new ArrayList<>();
+
+        for (MessageRoom room : rooms) {
+            Message lastMsg = messageRepository
+                    .findTopByMessageRoomIdOrderByCreatedAtDesc(room.getId())
+                    .orElse(null);
+
+            String lastMessage = lastMsg != null ? lastMsg.getContent() : null;
+            LocalDateTime lastMessageTime = lastMsg != null ? lastMsg.getCreatedAt() : null;
+            String lastMessageNickname = lastMsg != null ? computeDisplayName(lastMsg) : null;
+
+            Long targetId = room.getSenderId().equals(memberId) ? room.getReceiverId() : room.getSenderId();
+            String targetNickname = computeDisplayName(room, targetId);
+
+            int unreadCount = messageRepository.countByMessageRoomIdAndReceiverIdAndIsReadFalse(room.getId(), memberId);
+
+            result.add(new MessageRoomListResponse(
+                    room.getId(),
+                    room.getBoard().getId(),
+                    room.getBoard().getTitle(),
+                    lastMessage,
+                    lastMessageTime,
+                    lastMessageNickname,
+                    unreadCount,
+                    targetNickname
+            ));
+        }
+        return result;
     }
 
     //롱폴링
@@ -170,9 +212,30 @@ public class MessageService {
             return "작성자";
         } else {
             // 댓글을 통해 부여된 익명 번호 조회
-            Optional<Comment> commentOptional = commentRepository.findByBoardIdAndMemberId(board.getId(), message.getSenderId());
+            Optional<Comment> commentOptional = commentRepository.findByBoardIdAndMemberId(board.getId(),
+                                                                                           message.getSenderId());
             return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
                     .orElse("익명");
+        }
+    }
+
+    public String computeDisplayName(MessageRoom room, Long memberId) {
+        Board board = room.getBoard();
+        Long boardOwnerId = board.getMember().getId();
+
+        if (memberId.equals(boardOwnerId)) {
+            return "작성자";
+        } else {
+            Optional<Comment> commentOptional = commentRepository.findByBoardIdAndMemberId(board.getId(), memberId);
+            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
+                    .orElse("익명");
+        }
+    }
+
+    public void readAllUnreadMessages(Long roomId, Long memberId) {
+        List<Message> unreadMessages = messageRepository.findByMessageRoomIdAndReceiverIdAndIsReadFalse(roomId, memberId);
+        for (Message message : unreadMessages) {
+            message.setRead(true);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
내가 참여한 쪽지방 목록을 조회하는 API를 구현했습니다.

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 내가 참여한 쪽지방 목록 조회 API 추가 (/messages/rooms)
- 작업 2 마지막 메시지 내용, 시간, 닉네임, 읽지 않은 메시지 개수, 상대방 닉네임 정보 포함
- 작업 3 서비스, DTO, Repository 레이어 구현 및 리팩토링

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1 API 응답 구조 및 파라미터에 개선점이나 누락된 부분 있으면 피드백 부탁드립니다.
- 공유 사항 2 쪽지방 목록은 최신 메시지 기준으로 정렬됩니다.
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve a list of message rooms the user participates in, including last message details and unread message counts.
  * Messages are now marked as read when fetched by the recipient.

* **Improvements**
  * Enhanced message retrieval to provide more detailed information and user-friendly display names.
  * Added support for tracking and displaying unread message counts in message rooms.

* **Bug Fixes**
  * Corrected a typo in a success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->