### PR TITLE
[Fix ]쪽지방 롱폴링 로직 개선 및 시큐리티 권한 추가

### DIFF
--- a/src/main/java/backend/hiteen/HiteenApplication.java
+++ b/src/main/java/backend/hiteen/HiteenApplication.java
@@ -3,9 +3,11 @@ package backend.hiteen;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAsync
 public class HiteenApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -41,6 +41,8 @@ public enum ErrorCode {
     MESSAGE_TARGET_NOT_SPECIFIED(HttpStatus.BAD_REQUEST, "쪽지 받을 대상을 지정해 주세요."),
     COMMENT_ANONYMOUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 익명번호의 댓글이 존재하지 않습니다."),
     INVALID_MESSAGE_TARGET(HttpStatus.BAD_REQUEST, "쪽지 대상은 게시글 작성자 또는 특정 댓글러 중 하나만 지정할 수 있습니다."),
+    MESSAGE_ROOM_PERMISSION_DENIED(HttpStatus.FORBIDDEN,"이 쪽지방에 메시지를 보낼 권한이 없습니다."),
+
 
     //Meal
     MEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "급식 정보를 찾을 수 없습니다."),

--- a/src/main/java/backend/hiteen/global/config/SecurityConfig.java
+++ b/src/main/java/backend/hiteen/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package backend.hiteen.global.config;
 
 import backend.hiteen.auth.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers("/auth/login",
                                          "/auth/reissue",
                                          "/members/sign-up",

--- a/src/main/java/backend/hiteen/message/exception/MessageRoomNotOwnerException.java
+++ b/src/main/java/backend/hiteen/message/exception/MessageRoomNotOwnerException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.message.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class MessageRoomNotOwnerException extends BusinessException {
+    public MessageRoomNotOwnerException() {
+        super(ErrorCode.MESSAGE_ROOM_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/backend/hiteen/message/mapper/MessageMapper.java
+++ b/src/main/java/backend/hiteen/message/mapper/MessageMapper.java
@@ -1,0 +1,55 @@
+package backend.hiteen.message.mapper;
+
+import backend.hiteen.board.entity.Board;
+import backend.hiteen.comment.entity.Comment;
+import backend.hiteen.comment.repository.CommentRepository;
+import backend.hiteen.message.dto.response.MessageResponse;
+import backend.hiteen.message.entity.Message;
+import backend.hiteen.message.entity.MessageRoom;
+
+import java.util.Optional;
+
+public class MessageMapper {
+    private MessageMapper() {
+    }
+
+    // 작성자라면 작성자 댓글이면 익명번호 기반으로 조회
+    public static String computeDisplayName(Message message, CommentRepository commentRepository) {
+        Board board = message.getMessageRoom().getBoard();
+        Long boardOwnerId = board.getMember().getId();
+
+        if (message.getSenderId().equals(boardOwnerId)) {
+            return "작성자";
+        } else {
+            Optional<Comment> commentOptional =
+                    commentRepository.findByBoardIdAndMemberId(board.getId(), message.getSenderId());
+            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
+                    .orElse("익명");
+        }
+    }
+
+    public static String computeDisplayName(MessageRoom room, Long memberId, CommentRepository commentRepository) {
+        Board board = room.getBoard();
+        Long boardOwnerId = board.getMember().getId();
+
+        if (memberId.equals(boardOwnerId)) {
+            return "작성자";
+        } else {
+            Optional<Comment> commentOptional =
+                    commentRepository.findByBoardIdAndMemberId(board.getId(), memberId);
+            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
+                    .orElse("익명");
+        }
+    }
+
+    public static MessageResponse toDto(Message message, Long memberId, CommentRepository commentRepository) {
+        return new MessageResponse(
+                message.getId(),
+                message.getMessageRoom().getId(),
+                message.getContent(),
+                message.getCreatedAt(),
+                computeDisplayName(message, commentRepository),
+                message.getSenderId().equals(memberId)
+        );
+    }
+}

--- a/src/main/java/backend/hiteen/message/repository/MessageRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRepository.java
@@ -2,6 +2,9 @@ package backend.hiteen.message.repository;
 
 import backend.hiteen.message.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,7 +18,15 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     Optional<Message> findTopByMessageRoomIdOrderByCreatedAtDesc(Long messageRoomId);
 
     int countByMessageRoomIdAndReceiverIdAndIsReadFalse(Long roomId, Long memberId);
-    List<Message> findByMessageRoomIdAndReceiverIdAndIsReadFalse(Long roomId, Long receiverId);
+
+    @Modifying
+    @Query("UPDATE Message m " +
+            "SET m.isRead = true " +
+            "WHERE m.messageRoom.id = :roomId " +
+            "  AND m.receiverId = :memberId " +
+            "  AND m.isRead = false")
+    int markAllAsRead(@Param("roomId") Long roomId,
+                      @Param("memberId") Long memberId);
 
 }
 

--- a/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
@@ -29,4 +29,10 @@ public interface MessageRoomRepository extends JpaRepository<MessageRoom, Long> 
                     order by (select max(m.createdAt) from Message m where m.messageRoom = mr) desc
             """)
     List<MessageRoom> findAllByMember(@Param("memberId") Long memberId);
+
+    @Query("SELECT mr " +
+            "FROM MessageRoom mr " +
+            "WHERE mr.senderId = :memberId OR mr.receiverId = :memberId " +
+            "ORDER BY mr.updatedAt DESC")
+    List<MessageRoom> findAllByMemberOrderByUpdatedAtDesc(@Param("memberId") Long memberId);
 }

--- a/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
@@ -22,14 +22,6 @@ public interface MessageRoomRepository extends JpaRepository<MessageRoom, Long> 
             @Param("id1") Long id1,
             @Param("id2") Long id2);
 
-    @Query("""
-                    select mr
-                    from MessageRoom mr
-                    where mr.senderId = :memberId or mr.receiverId = :memberId
-                    order by (select max(m.createdAt) from Message m where m.messageRoom = mr) desc
-            """)
-    List<MessageRoom> findAllByMember(@Param("memberId") Long memberId);
-
     @Query("SELECT mr " +
             "FROM MessageRoom mr " +
             "WHERE mr.senderId = :memberId OR mr.receiverId = :memberId " +

--- a/src/main/java/backend/hiteen/message/service/MessageAsyncService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageAsyncService.java
@@ -1,0 +1,67 @@
+package backend.hiteen.message.service;
+
+import backend.hiteen.comment.repository.CommentRepository;
+import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.common.response.SuccessCode;
+import backend.hiteen.message.dto.response.MessageResponse;
+import backend.hiteen.message.entity.Message;
+import backend.hiteen.message.entity.MessageRoom;
+import backend.hiteen.message.mapper.MessageMapper;
+import backend.hiteen.message.repository.MessageRepository;
+import backend.hiteen.message.repository.MessageRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageAsyncService {
+
+    private final MessageRepository messageRepository;
+    private final MessageRoomRepository messageRoomRepository;
+    private final CommentRepository commentRepository;
+
+
+    @Async
+    public void pollMessagesAsync(
+            DeferredResult<ResponseEntity<ApiResponse<List<MessageResponse>>>> result,
+            Long roomId, Long lastMessageId, Long memberId) {
+        try {
+            MessageRoom room = messageRoomRepository.findById(roomId)
+                    .orElse(null);
+            if (room == null || (!room.getSenderId().equals(memberId) && !room.getReceiverId().equals(memberId))) {
+                result.setErrorResult(
+                        ResponseEntity.status(HttpStatus.FORBIDDEN)
+                                .body(ApiResponse.failure(ErrorCode.MESSAGE_ROOM_NOT_FOUND))
+                );
+                return;
+            }
+
+            // 2. 새 메시지 조회
+            List<Message> newMessages = messageRepository.findByMessageRoomIdOrderByCreatedAtAsc(roomId)
+                    .stream()
+                    .filter(m -> m.getId() > lastMessageId)
+                    .toList();
+
+            List<MessageResponse> body = newMessages.stream()
+                    .map(m -> MessageMapper.toDto(m, memberId, commentRepository))
+                    .toList();
+
+            ResponseEntity<ApiResponse<List<MessageResponse>>> response =
+                    ResponseEntity.status(SuccessCode.MESSAGE_POLLED.getStatus())
+                            .body(ApiResponse.success(SuccessCode.MESSAGE_POLLED, body));
+            result.setResult(response);
+        } catch (Exception e) {
+            result.setErrorResult(
+                    ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .body(ApiResponse.failure(ErrorCode.INTERNAL_SERVER_ERROR))
+            );
+        }
+    }
+}

--- a/src/main/java/backend/hiteen/message/service/MessageService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageService.java
@@ -14,6 +14,7 @@ import backend.hiteen.message.dto.response.MessageRoomListResponse;
 import backend.hiteen.message.entity.Message;
 import backend.hiteen.message.entity.MessageRoom;
 import backend.hiteen.message.exception.*;
+import backend.hiteen.message.mapper.MessageMapper;
 import backend.hiteen.message.repository.MessageRepository;
 import backend.hiteen.message.repository.MessageRoomRepository;
 import lombok.AllArgsConstructor;
@@ -34,17 +35,11 @@ public class MessageService {
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
     private final MessageRoomRepository messageRoomRepository;
+    private final MessageAsyncService messageAsyncService;
 
 
     public MessageResponse toDto(Message message, Long memberId) {
-        return new MessageResponse(
-                message.getId(),
-                message.getMessageRoom().getId(),
-                message.getContent(),
-                message.getCreatedAt(),
-                computeDisplayName(message),
-                message.getSenderId().equals(memberId)
-        );
+        return MessageMapper.toDto(message, memberId, commentRepository);
     }
 
     // 대화 방 생성 및 메시지 전송
@@ -103,6 +98,7 @@ public class MessageService {
         Message message = Message.builder()
                 .messageRoom(messageRoom)
                 .senderId(memberId)
+                .receiverId(receiverId)
                 .content(request.getContent())
                 .build();
 
@@ -117,11 +113,17 @@ public class MessageService {
                 .orElseThrow(MessageRoomNotFoundException::new);
 
         if (!memberId.equals(room.getSenderId()) && !memberId.equals(room.getReceiverId())) {
-            throw new IllegalArgumentException("이 쪽지방에 메시지를 보낼 권한이 없습니다.");
+            throw new MessageRoomNotOwnerException();
         }
+
+        Long otherId = room.getSenderId().equals(memberId)
+                ? room.getReceiverId()
+                : room.getSenderId();
+
         Message message = Message.builder()
                 .messageRoom(room)
                 .senderId(memberId)
+                .receiverId(otherId)
                 .content(content)
                 .build();
 
@@ -140,18 +142,10 @@ public class MessageService {
                 .toList();
     }
 
-    public List<Message> getMessageAfter(Long roomId, Long lastMessageId) {
-        return messageRepository.findByMessageRoomIdOrderByCreatedAtAsc(roomId)
-                .stream()
-                .filter(m -> m.getId() > lastMessageId)
-                .toList();
-    }
-
     public List<MessageRoomListResponse> getMyMessageRooms(Long memberId) {
-        List<MessageRoom> rooms = messageRoomRepository.findAllByMember(memberId);
+        List<MessageRoom> rooms = messageRoomRepository.findAllByMemberOrderByUpdatedAtDesc(memberId);
 
         List<MessageRoomListResponse> result = new ArrayList<>();
-
         for (MessageRoom room : rooms) {
             Message lastMsg = messageRepository
                     .findTopByMessageRoomIdOrderByCreatedAtDesc(room.getId())
@@ -159,10 +153,10 @@ public class MessageService {
 
             String lastMessage = lastMsg != null ? lastMsg.getContent() : null;
             LocalDateTime lastMessageTime = lastMsg != null ? lastMsg.getCreatedAt() : null;
-            String lastMessageNickname = lastMsg != null ? computeDisplayName(lastMsg) : null;
+            String lastMessageNickname = lastMsg != null ? MessageMapper.computeDisplayName(lastMsg, commentRepository) : null;
 
             Long targetId = room.getSenderId().equals(memberId) ? room.getReceiverId() : room.getSenderId();
-            String targetNickname = computeDisplayName(room, targetId);
+            String targetNickname = MessageMapper.computeDisplayName(room, targetId, commentRepository);
 
             int unreadCount = messageRepository.countByMessageRoomIdAndReceiverIdAndIsReadFalse(room.getId(), memberId);
 
@@ -186,57 +180,16 @@ public class MessageService {
         DeferredResult<ResponseEntity<ApiResponse<List<MessageResponse>>>> result =
                 new DeferredResult<>(timeout);
 
-        new Thread(() -> {
-            List<MessageResponse> body = getMessageAfter(roomId, lastMessageId).stream()
-                    .map(m -> toDto(m, memberId))
-                    .toList();
-            ResponseEntity<ApiResponse<List<MessageResponse>>> response =
-                    ResponseEntity
-                            .status(SuccessCode.MESSAGE_POLLED.getStatus())
-                            .body(ApiResponse.success(SuccessCode.MESSAGE_POLLED, body));
+        messageAsyncService.pollMessagesAsync(result, roomId, lastMessageId, memberId);
 
-            result.setResult(response);
-        }).start();
+        result.onTimeout(() -> result.setResult(
+                ResponseEntity.ok(ApiResponse.success(SuccessCode.MESSAGE_POLLED, List.of()))
+        ));
 
         return result;
     }
 
-
-    // 작성자라면 작성자 댓글이면 익명번호 기반으로 조회
-    public String computeDisplayName(Message message) {
-        Board board = message.getMessageRoom().getBoard();
-        Long boardOwnerId = board.getMember().getId();
-
-        // 메시지 보낸 사람이 게시글 작성자라면
-        if (message.getSenderId().equals(boardOwnerId)) {
-            return "작성자";
-        } else {
-            // 댓글을 통해 부여된 익명 번호 조회
-            Optional<Comment> commentOptional = commentRepository.findByBoardIdAndMemberId(board.getId(),
-                                                                                           message.getSenderId());
-            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
-                    .orElse("익명");
-        }
-    }
-
-    public String computeDisplayName(MessageRoom room, Long memberId) {
-        Board board = room.getBoard();
-        Long boardOwnerId = board.getMember().getId();
-
-        if (memberId.equals(boardOwnerId)) {
-            return "작성자";
-        } else {
-            Optional<Comment> commentOptional = commentRepository.findByBoardIdAndMemberId(board.getId(), memberId);
-            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
-                    .orElse("익명");
-        }
-    }
-
     public void readAllUnreadMessages(Long roomId, Long memberId) {
-        List<Message> unreadMessages = messageRepository.findByMessageRoomIdAndReceiverIdAndIsReadFalse(roomId, memberId);
-        for (Message message : unreadMessages) {
-            message.setRead(true);
-        }
+        messageRepository.markAllAsRead(roomId, memberId);
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -22,3 +22,4 @@ spring:
 openapi:
   base-url: https://open.neis.go.kr/hub
   api-key: ${NEIS_API_KEY}
+


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
롱폴링 메시지 조회 시 발생하던 **403 권한 오류**를 해결 및 쪽지 서비스 주요 로직을 성능 개선

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 SecurityConfig에 .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll() 추가
- 작업 2 sendMessageInRoom의 receiverId 결정 로직을 otherId 계산 방식으로 수정
- 작업 3 MessageRepository 읽음 여부 추가 및 쪽지 조회 시 정렬 적용

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1 ASYNC 권한 허용으로 롱폴링 403 이슈가 해결되었습니다.
- 공유 사항 2 MessageRoom.updatedAt 필드가 메시지 전송 시 자동 갱신되는지 확인이 필요합니다.
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #92 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled asynchronous processing for improved message polling performance.
  * Added permission checks and clear error messaging when sending messages in rooms without proper access.
  * Introduced new error messages for permission denial in message rooms.

* **Improvements**
  * Message rooms are now listed in order of most recent activity.
  * Display names in messages are now shown more clearly, distinguishing between authors and anonymous users.
  * Marking all messages as read is now more efficient.

* **Bug Fixes**
  * Enhanced handling of unauthorized message room access.

* **Chores**
  * Updated database schema management to preserve existing data on application restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->