### PR TITLE
fix : 익명 댓글번호 별 별도 쪽지방으로 생성되도록 수정

### DIFF
--- a/src/main/java/backend/hiteen/message/controller/MessageController.java
+++ b/src/main/java/backend/hiteen/message/controller/MessageController.java
@@ -69,7 +69,7 @@ public class MessageController {
                 .body(ApiResponse.success(SuccessCode.MESSAGES_FETCHED, responseList));
     }
 
-        @GetMapping("/rooms")
+    @GetMapping("/rooms")
     @Operation(summary = "참여한 쪽지방 목록 조회", description = "사용자가 참여한 모든 쪽지방 목록을 최신 메세지 기준으로 조회합니다.")
     public ResponseEntity<ApiResponse<List<MessageRoomListResponse>>> getMyMessageRooms(
             @AuthenticationPrincipal CustomUserPrincipal principal

--- a/src/main/java/backend/hiteen/message/entity/MessageRoom.java
+++ b/src/main/java/backend/hiteen/message/entity/MessageRoom.java
@@ -9,8 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor
@@ -28,5 +26,7 @@ public class MessageRoom extends BaseTimeEntity {
     private Long senderId;
 
     private Long receiverId;
+
+    private Integer anonymousNumber;
 
 }

--- a/src/main/java/backend/hiteen/message/mapper/MessageMapper.java
+++ b/src/main/java/backend/hiteen/message/mapper/MessageMapper.java
@@ -1,54 +1,50 @@
 package backend.hiteen.message.mapper;
 
-import backend.hiteen.board.entity.Board;
-import backend.hiteen.comment.entity.Comment;
-import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.message.dto.response.MessageResponse;
 import backend.hiteen.message.entity.Message;
 import backend.hiteen.message.entity.MessageRoom;
 
-import java.util.Optional;
 
 public class MessageMapper {
     private MessageMapper() {
     }
 
-    // 작성자라면 작성자 댓글이면 익명번호 기반으로 조회
-    public static String computeDisplayName(Message message, CommentRepository commentRepository) {
-        Board board = message.getMessageRoom().getBoard();
-        Long boardOwnerId = board.getMember().getId();
+    // 메시지 단건 DTO 변환 시
+    public static String computeDisplayName(Message message) {
+        MessageRoom room = message.getMessageRoom();
+        Long boardOwnerId = room.getBoard().getMember().getId();
 
+        // 1) 작성자 본인이 보낸 메시지면 “작성자”
         if (message.getSenderId().equals(boardOwnerId)) {
             return "작성자";
-        } else {
-            Optional<Comment> commentOptional =
-                    commentRepository.findByBoardIdAndMemberId(board.getId(), message.getSenderId());
-            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
-                    .orElse("익명");
         }
+        // 2) 익명번호가 있으면 “익명 {번호}”, 없으면 “익명”
+        Integer anonNum = room.getAnonymousNumber();
+        return anonNum != null
+                ? "익명 " + anonNum
+                : "익명";
     }
 
-    public static String computeDisplayName(MessageRoom room, Long memberId, CommentRepository commentRepository) {
-        Board board = room.getBoard();
-        Long boardOwnerId = board.getMember().getId();
+    // 방 목록 DTO 변환 시
+    public static String computeDisplayName(MessageRoom room, Long memberId) {
+        Long boardOwnerId = room.getBoard().getMember().getId();
 
         if (memberId.equals(boardOwnerId)) {
             return "작성자";
-        } else {
-            Optional<Comment> commentOptional =
-                    commentRepository.findByBoardIdAndMemberId(board.getId(), memberId);
-            return commentOptional.map(comment -> "익명 " + comment.getAnonymousNumber())
-                    .orElse("익명");
         }
+        Integer anonNum = room.getAnonymousNumber();
+        return anonNum != null
+                ? "익명 " + anonNum
+                : "익명";
     }
 
-    public static MessageResponse toDto(Message message, Long memberId, CommentRepository commentRepository) {
+    public static MessageResponse toDto(Message message, Long memberId) {
         return new MessageResponse(
                 message.getId(),
                 message.getMessageRoom().getId(),
                 message.getContent(),
                 message.getCreatedAt(),
-                computeDisplayName(message, commentRepository),
+                computeDisplayName(message),
                 message.getSenderId().equals(memberId)
         );
     }

--- a/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRoomRepository.java
@@ -12,15 +12,21 @@ import java.util.Optional;
 public interface MessageRoomRepository extends JpaRepository<MessageRoom, Long> {
 
     @Query("""
-            select mr from MessageRoom mr
-            where mr.board.id = :boardId
-            and ((mr.senderId = :id1 and mr.receiverId = :id2)
-            or (mr.senderId = :id2 and mr.receiverId = :id1))
+                select mr
+                from MessageRoom mr
+                where mr.board.id = :boardId
+                and ((mr.senderId = :id1 and mr.receiverId = :id2)
+                or (mr.senderId = :id2 and mr.receiverId = :id1))
+                and ((:anonNum is null and mr.anonymousNumber is null)
+                or ( :anonNum is not null and mr.anonymousNumber = :anonNum))
             """)
-    Optional<MessageRoom> findByBoardIdAndParticipants(
+    Optional<MessageRoom> findByBoardAndParticipantsAndAnon(
             @Param("boardId") Long boardId,
             @Param("id1") Long id1,
-            @Param("id2") Long id2);
+            @Param("id2") Long id2,
+            @Param("anonNum") Integer anonymousNumber
+    );
+
 
     @Query("SELECT mr " +
             "FROM MessageRoom mr " +

--- a/src/main/java/backend/hiteen/message/service/MessageAsyncService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageAsyncService.java
@@ -1,6 +1,5 @@
 package backend.hiteen.message.service;
 
-import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.common.response.ApiResponse;
 import backend.hiteen.common.response.ErrorCode;
 import backend.hiteen.common.response.SuccessCode;
@@ -25,7 +24,6 @@ public class MessageAsyncService {
 
     private final MessageRepository messageRepository;
     private final MessageRoomRepository messageRoomRepository;
-    private final CommentRepository commentRepository;
 
 
     @Async
@@ -50,7 +48,7 @@ public class MessageAsyncService {
                     .toList();
 
             List<MessageResponse> body = newMessages.stream()
-                    .map(m -> MessageMapper.toDto(m, memberId, commentRepository))
+                    .map(m -> MessageMapper.toDto(m, memberId))
                     .toList();
 
             ResponseEntity<ApiResponse<List<MessageResponse>>> response =

--- a/src/main/java/backend/hiteen/message/service/MessageService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageService.java
@@ -26,7 +26,6 @@ import org.springframework.web.context.request.async.DeferredResult;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @AllArgsConstructor
@@ -39,7 +38,7 @@ public class MessageService {
 
 
     public MessageResponse toDto(Message message, Long memberId) {
-        return MessageMapper.toDto(message, memberId, commentRepository);
+        return MessageMapper.toDto(message, memberId);
     }
 
     // 대화 방 생성 및 메시지 전송
@@ -49,61 +48,49 @@ public class MessageService {
                 .orElseThrow(BoardNotFoundException::new);
 
         Long receiverId;
+        final Integer anonNum;
 
-        //둘 다 동시에 값 들어오지 않게
-        if (Boolean.TRUE.equals(request.getIsBoardWriter()) && request.getAnonymousNumber() != null) {
-            throw new InvalidMessageTargetException();
-        }
-
-        //작성자에게 쪽지보냄
+        // 작성자에게 보내는 경우
         if (Boolean.TRUE.equals(request.getIsBoardWriter())) {
             receiverId = board.getMember().getId();
-
-            if (receiverId.equals(memberId)) {
-                throw new CannotSendMessageToSelfException();
-            }
-            //익명 댓글러에게 쪽지보냄
-        } else if (request.getAnonymousNumber() != null) {
-            Comment comment = commentRepository.findByBoardIdAndAnonymousNumber(
-                    request.getBoardId(), request.getAnonymousNumber()
-            ).orElseThrow(CommentAnonymousNotFoundException::new);
-
+            anonNum = null;
+            if (receiverId.equals(memberId)) throw new CannotSendMessageToSelfException();
+        }
+        // 익명 댓글러에게 보내는 경우
+        else if (request.getAnonymousNumber() != null) {
+            Comment comment = commentRepository
+                    .findByBoardIdAndAnonymousNumber(board.getId(), request.getAnonymousNumber())
+                    .orElseThrow(CommentAnonymousNotFoundException::new);
             receiverId = comment.getMember().getId();
-
-            if (receiverId.equals(memberId)) {
-                throw new CannotSendMessageToSelfException();
-            }
-
-        } else {
+            anonNum = comment.getAnonymousNumber();
+            if (receiverId.equals(memberId)) throw new CannotSendMessageToSelfException();
+        }
+        else {
             throw new MessageTargetNotSpecifiedException();
         }
 
-        Optional<MessageRoom> optionalRoom =
-                messageRoomRepository.findByBoardIdAndParticipants(
-                        request.getBoardId(), memberId, receiverId
-                );
-
-        MessageRoom messageRoom = optionalRoom.orElse(null);
-
-        if (messageRoom == null) {
-            messageRoom = MessageRoom.builder()
-                    .board(board)
-                    .senderId(memberId)
-                    .receiverId(receiverId)
-                    .build();
-
-            messageRoom = messageRoomRepository.save(messageRoom);
-        }
+        MessageRoom room = messageRoomRepository
+                .findByBoardAndParticipantsAndAnon(
+                        board.getId(), memberId, receiverId, anonNum
+                )
+                .orElseGet(() -> messageRoomRepository.save(
+                        MessageRoom.builder()
+                                .board(board)
+                                .senderId(memberId)
+                                .receiverId(receiverId)
+                                .anonymousNumber(anonNum)
+                                .build()
+                ));
 
         Message message = Message.builder()
-                .messageRoom(messageRoom)
+                .messageRoom(room)
                 .senderId(memberId)
                 .receiverId(receiverId)
                 .content(request.getContent())
                 .build();
-
         return messageRepository.save(message);
     }
+
 
     // 대화 방 내 메세지 전송
 
@@ -153,10 +140,10 @@ public class MessageService {
 
             String lastMessage = lastMsg != null ? lastMsg.getContent() : null;
             LocalDateTime lastMessageTime = lastMsg != null ? lastMsg.getCreatedAt() : null;
-            String lastMessageNickname = lastMsg != null ? MessageMapper.computeDisplayName(lastMsg, commentRepository) : null;
+            String lastMessageNickname = lastMsg != null ? MessageMapper.computeDisplayName(lastMsg) : null;
 
             Long targetId = room.getSenderId().equals(memberId) ? room.getReceiverId() : room.getSenderId();
-            String targetNickname = MessageMapper.computeDisplayName(room, targetId, commentRepository);
+            String targetNickname = MessageMapper.computeDisplayName(room, targetId);
 
             int unreadCount = messageRepository.countByMessageRoomIdAndReceiverIdAndIsReadFalse(room.getId(), memberId);
 


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
 익명 댓글별 방 분리

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 MessageRoom 엔티티에 anonymousNumber 필드 추가하여 익명번호까지 포함해 방을 찾는 쿼리로 수정


## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1 message_room 테이블에 anonymous_number 칼럼 추가를 위한 마이그레이션
- 공유 사항 2
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #94 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for anonymous numbers in message rooms, enabling clearer identification of anonymous participants in conversations.

* **Refactor**
  * Simplified how display names are generated for messages, now directly using anonymous numbers from message rooms.
  * Streamlined message room retrieval and creation based on anonymous numbers for more accurate participant matching.

* **Bug Fixes**
  * Improved handling of self-message checks and anonymous participant assignment for more consistent messaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->