### PR TITLE
[feat/#99]: 이메일 중복 확인 기능 구현

### DIFF
--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -8,33 +8,33 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
 
-    //member
+    //Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     MEMBER_PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 정보가 유효하지 않습니다."),
     MEMBER_REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 Refresh Token이 없습니다."),
     MEMBER_REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
 
-    //board
+    //Board
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
     BOARD_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 작성에 실패했습니다."),
     KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요."),
     NO_PERMISSION_TO_DELETE_BOARD(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
 
-    //comment
+    //Comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
     COMMENT_PERMISSION_DENIED(HttpStatus.FORBIDDEN,"댓글에 대한 권한이 없습니다."),
 
-    //love
+    //Love
     LOVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
     LOVE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
 
-    //scrap
+    //Scrap
     SCRAP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스크랩한 게시글입니다."),
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "스크랩 정보가 존재하지 않습니다."),
 
-    //message
+    //Message
     MESSAGE_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "쪽지방을 찾을 수 없습니다."),
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "쪽지를 찾을 수 없습니다."),
     CANNOT_SEND_MESSAGE_TO_SELF(HttpStatus.BAD_REQUEST, "자기 자신에게 쪽지를 보낼 수 없습니다."),

--- a/src/main/java/backend/hiteen/common/response/SuccessCode.java
+++ b/src/main/java/backend/hiteen/common/response/SuccessCode.java
@@ -6,8 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum SuccessCode {
 
-    //member
+    //Member
     MEMBER_REGISTERED(HttpStatus.CREATED, "회원가입이 완료되었습니다."),
+    MEMBER_EMAIL_AVAILABLE(HttpStatus.OK, "사용 가능한 이메일입니다."),
     MEMBER_FETCHED(HttpStatus.OK, "회원 정보를 조회합니다."),
     MEMBER_UPDATED(HttpStatus.OK, "회원 정보를 수정합니다."),
     MEMBER_LOGGED_IN(HttpStatus.OK, "로그인이 완료되었습니다."),
@@ -16,7 +17,7 @@ public enum SuccessCode {
     MEMBER_LOGOUT(HttpStatus.OK, "로그아웃되었습니다."),
 
 
-    //board
+    //Board
     BOARD_CREATED(HttpStatus.CREATED, "게시글이 등록되었습니다."),
     BOARD_DETAIL_FETCHED(HttpStatus.OK, "게시글을 단일 조회했습니다."),
     BOARD_ALL_FETCHED(HttpStatus.OK, "모든 게시글 목록을 조회했습니다."),
@@ -25,7 +26,7 @@ public enum SuccessCode {
     SEARCHED_BOARD_LIST_FETCHED(HttpStatus.OK, "검색된 게시글 목록을 조회했습니다."),
     BOARD_DELETED(HttpStatus.OK, "게시글이 성공적으로 삭제되었습니다."),
 
-    //comment
+    //Comment
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),
     REPLY_CREATED(HttpStatus.CREATED,"대댓글이 등록되었습니다."),
     COMMENT_FETCHED(HttpStatus.OK, "댓글 목록을 불러왔습니다."),
@@ -34,17 +35,17 @@ public enum SuccessCode {
     COMMENT_LIKED_DELETED(HttpStatus.OK, "댓글 좋아요가 취소되었습니다."),
 
 
-    //love
+    //Love
     LOVE_CREATED(HttpStatus.CREATED, "게시글에 좋아요를 눌렀습니다."),
     LOVE_DELETED(HttpStatus.OK, "게시글 좋아요를 취소했습니다."),
     LOVED_BOARDS_FETCHED(HttpStatus.OK, "좋아요한 게시글 목록을 조회했습니다."),
 
-    //scrap
+    //Scrap
     SCRAP_CREATED(HttpStatus.CREATED, "게시글이 스크랩되었습니다."),
     SCRAP_DELETED(HttpStatus.OK, "게시글 스크랩이 취소되었습니다."),
     SCRAPED_BOARDS_FETCHED(HttpStatus.OK, "스크랩한 게시글 목록을 조회했습니다."),
 
-    //message
+    //Message
     MESSAGE_ROOM_CREATED(HttpStatus.CREATED, "쪽지방이 생성되었습니다."),
     MESSAGE_SENT(HttpStatus.CREATED, "쪽지를 보냈습니다."),
     MESSAGE_SENT_IN_ROOM(HttpStatus.CREATED, "쪽지방에 메시지를 보냈습니다."),

--- a/src/main/java/backend/hiteen/global/config/SecurityConfig.java
+++ b/src/main/java/backend/hiteen/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login",
                                          "/auth/reissue",
                                          "/members/sign-up",
+                                        "/members/email/availability",
                                          "/swagger-ui/**",
                                          "/v3/api-docs/**",
                                          "/actuator/**",

--- a/src/main/java/backend/hiteen/member/controller/MemberController.java
+++ b/src/main/java/backend/hiteen/member/controller/MemberController.java
@@ -30,6 +30,13 @@ public class MemberController {
         return ResponseEntity.status(SuccessCode.MEMBER_REGISTERED.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_REGISTERED, memberResponse));
     }
 
+    @GetMapping("/email/availability")
+    @Operation(summary = "이메일 중복 확인", description = "이메일 중복 확인을 합니다.")
+    public ResponseEntity<ApiResponse<Void>> checkEmailAvailable(@Valid @RequestParam String email){
+        memberService.checkEmailAvailable(email);
+        return ResponseEntity.status(SuccessCode.MEMBER_EMAIL_AVAILABLE.getStatus()).body(ApiResponse.success(SuccessCode.MEMBER_EMAIL_AVAILABLE));
+    }
+
     // 내 정보 조회
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회", description = "로그인된 내 회원 정보를 조회합니다.")

--- a/src/main/java/backend/hiteen/member/service/MemberService.java
+++ b/src/main/java/backend/hiteen/member/service/MemberService.java
@@ -38,6 +38,11 @@ public class MemberService {
         return new MemberResponse(member);
     }
 
+    //이메일 중복 확인
+    public void checkEmailAvailable(String email){
+        validateDuplicateEmail(email);
+    }
+
 
     //이메일 중복 예외처리
     private void validateDuplicateEmail(String email){


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 이메일 중복 확인 API 구현

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 이메일 중복 확인 기능 구현
- 사용 가능한 이메일인 경우 Success Code 반환
- 사용 중인 이메일인 경우 Exception Error Code 반환
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public endpoint to check if an email is available for registration.
  * Users can now verify email availability before signing up.

* **Improvements**
  * Updated error and success messages for email-related responses to improve clarity.
  * Minor updates to comment formatting in response codes for consistency.

* **Security**
  * The email availability check endpoint is now accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->