### PR TITLE
[Fix] 모든 도메인 학교별 권한 분리 및 개선

### DIFF
--- a/src/main/java/backend/hiteen/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/backend/hiteen/auth/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -16,7 +15,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/backend/hiteen/auth/service/AuthService.java
+++ b/src/main/java/backend/hiteen/auth/service/AuthService.java
@@ -13,7 +13,6 @@ import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/backend/hiteen/board/controller/BoardController.java
+++ b/src/main/java/backend/hiteen/board/controller/BoardController.java
@@ -30,47 +30,75 @@ public class BoardController {
     public ResponseEntity<ApiResponse<BoardResponse>> createBoard(@AuthenticationPrincipal CustomUserPrincipal principal,
                                                                  @Valid @RequestBody BoardCreateRequest request){
         BoardResponse response=boardService.createBoard(principal.getUsername(),request);
-        return ResponseEntity.status(SuccessCode.BOARD_CREATED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_CREATED,response));
+        return ResponseEntity
+                .status(SuccessCode.BOARD_CREATED.getStatus())
+                .body(ApiResponse.success(SuccessCode.BOARD_CREATED,response));
     }
 
 
-    @GetMapping("/boards")
-    @Operation(summary = "전체 게시글 목록 조회", description = "모든 사용자가 작성한 게시글을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllBoards(){
-        List<BoardResponse> responses=boardService.getAllBoards();
-        return ResponseEntity.status(SuccessCode.BOARD_ALL_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_ALL_FETCHED, responses));
+    @GetMapping
+    @Operation(summary = "전체 게시글 목록 조회", description = "본인 학교의 게시글 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllBoards(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ){
+        List<BoardResponse> responses=boardService.getAllBoards(principal.getId());
+        return ResponseEntity
+                .status(SuccessCode.BOARD_ALL_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.BOARD_ALL_FETCHED, responses));
     }
 
     @GetMapping("/{boardId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글 ID를 통해 특정 게시글의 상세 내용을 조회합니다.")
-    public ResponseEntity<ApiResponse<BoardResponse>> getBoardById(@PathVariable Long boardId){
-        BoardResponse boardResponse=boardService.getBoardById(boardId);
-        return ResponseEntity.status(SuccessCode.BOARD_DETAIL_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.BOARD_DETAIL_FETCHED,boardResponse));
+    public ResponseEntity<ApiResponse<BoardResponse>> getBoardById(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long boardId){
+        BoardResponse boardResponse=boardService.getBoardById(boardId, principal.getId());
+        return ResponseEntity
+                .status(SuccessCode.BOARD_DETAIL_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.BOARD_DETAIL_FETCHED,boardResponse));
     }
 
-    @GetMapping("/my")
+    @GetMapping("/me")
     @Operation(summary = "내가 작성한 게시글 목록 조회", description = "사용자가 자신이 작성한 게시글 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllMyBoards(@AuthenticationPrincipal CustomUserPrincipal principal){
-        List<BoardResponse> responses=boardService.getAllMyBoards(principal.getUsername());
-        return ResponseEntity.status(SuccessCode.MY_BOARD_LIST_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.MY_BOARD_LIST_FETCHED, responses));
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllMyBoards(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        Long memberId = principal.getId();
+        List<BoardResponse> responses = boardService.getAllMyBoards(memberId);
+        return ResponseEntity
+                .status(SuccessCode.MY_BOARD_LIST_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.MY_BOARD_LIST_FETCHED, responses));
     }
+
 
     @GetMapping("/popular")
     @Operation(summary ="인기게시글 목록 조회", description = "인기게시글을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<BoardResponse>>> getPopularBoards(){
-        List<BoardResponse> responses=boardService.getPopularBoards();
-        return ResponseEntity.status(SuccessCode.POPULAR_BOARD_ALL_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.POPULAR_BOARD_ALL_FETCHED, responses));
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> getPopularBoards(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ){
+        List<BoardResponse> responses=boardService.getPopularBoards(principal.getId());
+        return ResponseEntity
+                .status(SuccessCode.POPULAR_BOARD_ALL_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.POPULAR_BOARD_ALL_FETCHED, responses));
     }
 
     @GetMapping("/search")
     @Operation(summary ="게시글 검색", description = "게시글을 검색합니다.")
-    public ResponseEntity<ApiResponse<List<BoardResponse>>> searchBoards(@RequestParam("keyword") String keyword){
-        List<BoardResponse> responses=boardService.searchBoards(keyword);
-        return ResponseEntity.status(SuccessCode.SEARCHED_BOARD_LIST_FETCHED.getStatus()).body(ApiResponse.success(SuccessCode.SEARCHED_BOARD_LIST_FETCHED, responses));
+    public ResponseEntity<ApiResponse<List<BoardResponse>>> searchBoards(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestParam("keyword") String keyword){
+
+        List<BoardResponse> responses=boardService.searchBoards(keyword, principal.getId());
+        return ResponseEntity
+                .status(SuccessCode.SEARCHED_BOARD_LIST_FETCHED.getStatus())
+                .body(ApiResponse.success(SuccessCode.SEARCHED_BOARD_LIST_FETCHED, responses));
     }
 
     @DeleteMapping("/{boardId}")
-    public ResponseEntity<ApiResponse<Void>> deleteBoard(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long boardId){
+    public ResponseEntity<ApiResponse<Void>> deleteBoard(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long boardId
+    ){
         boardService.deleteBoard(principal.getUsername(),boardId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.BOARD_DELETED));
     }

--- a/src/main/java/backend/hiteen/board/exception/BoardCreationFailedException.java
+++ b/src/main/java/backend/hiteen/board/exception/BoardCreationFailedException.java
@@ -1,8 +1,0 @@
-package backend.hiteen.board.exception;
-
-import backend.hiteen.common.response.ErrorCode;
-import backend.hiteen.global.exception.BusinessException;
-
-public class BoardCreationFailedException extends BusinessException {
-    public BoardCreationFailedException() {super(ErrorCode.BOARD_NOT_FOUND);}
-}

--- a/src/main/java/backend/hiteen/board/exception/BoardNotOwnerException.java
+++ b/src/main/java/backend/hiteen/board/exception/BoardNotOwnerException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.board.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class BoardNotOwnerException extends BusinessException {
+    public BoardNotOwnerException() {
+        super(ErrorCode.BOARD_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/backend/hiteen/board/repository/BoardRepository.java
+++ b/src/main/java/backend/hiteen/board/repository/BoardRepository.java
@@ -9,10 +9,23 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board,Long> {
-    List<Board> findAllByMember(Member member);
-    @Query("SELECT board FROM Board board WHERE (board.viewCount+board.loveCount)>=30")
-    List<Board> findPopularBoards();
+    List<Board> findAllByMember_School_Id(Long schoolId);
 
-    @Query("SELECT board FROM Board board WHERE board.title LIKE %:keyword% OR board.content LIKE %:keyword% OR board.member.name LIKE %:keyword% ORDER BY board.createdAt DESC")
-    List<Board> searchByKeyword(@Param("keyword") String keyword);
+    List<Board> findAllByMemberAndMember_School_Id(Member member, Long schoolId);
+
+    @Query("SELECT board FROM Board board WHERE (board.viewCount+board.loveCount)>=30")
+    List<Board> findPopularBoardsBySchool(Long schoolId);
+
+    @Query("""
+    SELECT board FROM Board board
+    WHERE board.member.school.id = :schoolId
+      AND (
+           board.title LIKE %:keyword%
+        OR board.content LIKE %:keyword%
+        OR board.member.name LIKE %:keyword%
+      )
+    ORDER BY board.createdAt DESC
+""")
+    List<Board> searchByKeyword(@Param("keyword") String keyword, @Param("schoolId") Long schoolId);
+
 }

--- a/src/main/java/backend/hiteen/board/repository/BoardRepository.java
+++ b/src/main/java/backend/hiteen/board/repository/BoardRepository.java
@@ -13,7 +13,7 @@ public interface BoardRepository extends JpaRepository<Board,Long> {
 
     List<Board> findAllByMemberAndMember_School_Id(Member member, Long schoolId);
 
-    @Query("SELECT board FROM Board board WHERE (board.viewCount+board.loveCount)>=30")
+    @Query("SELECT board FROM Board board WHERE (board.viewCount + board.loveCount) >= 30 AND board.member.school.id = :schoolId")
     List<Board> findPopularBoardsBySchool(Long schoolId);
 
     @Query("""

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -3,9 +3,7 @@ package backend.hiteen.board.service;
 import backend.hiteen.board.dto.request.BoardCreateRequest;
 import backend.hiteen.board.dto.response.BoardResponse;
 import backend.hiteen.board.entity.Board;
-import backend.hiteen.board.exception.BoardNotFoundException;
-import backend.hiteen.board.exception.KeywordRequiredException;
-import backend.hiteen.board.exception.NoPermissionToDeleteBoardException;
+import backend.hiteen.board.exception.*;
 import backend.hiteen.board.exception.BoardNotFoundException;
 import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.member.entity.Member;
@@ -117,7 +115,7 @@ public class BoardService {
 
     private void validateSameSchool(Member a, Member b) {
         if (!a.getSchool().getId().equals(b.getSchool().getId())) {
-            throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
+            throw new BoardNotOwnerException();
         }
     }
 

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -3,10 +3,12 @@ package backend.hiteen.board.service;
 import backend.hiteen.board.dto.request.BoardCreateRequest;
 import backend.hiteen.board.dto.response.BoardResponse;
 import backend.hiteen.board.entity.Board;
+import backend.hiteen.board.exception.BoardNotFoundException;
 import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.common.response.ErrorCode;
 import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.entity.Member;
+import backend.hiteen.member.exception.MemberNotFoundException;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,50 +39,65 @@ public class BoardService {
         return new BoardResponse(board);
     }
 
-    //게시글 전체 조회 - 모든 사용자에 대한
+    //게시글 전체 조회 - 사용자에 대한
     @Transactional(readOnly = true)
-    public List<BoardResponse> getAllBoards() {
-        List<Board> boards = boardRepository.findAll();
-        return boards.stream().map(BoardResponse::new).toList();
+    public List<BoardResponse> getAllBoards(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        Long schoolId = member.getSchool().getId();
 
+        List<Board> boards = boardRepository.findAllByMember_School_Id(schoolId);
+        return boards.stream().map(BoardResponse::new).toList();
     }
 
+    // 내가 내 학교에서 쓴 글만!
+    @Transactional(readOnly = true)
+    public List<BoardResponse> getAllMyBoards(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        Long schoolId = member.getSchool().getId();
+        List<Board> boards = boardRepository.findAllByMemberAndMember_School_Id(member, schoolId);
+        return boards.stream().map(BoardResponse::new).toList();
+    }
+
+
     //게시글 단일 조회 - 모든 사용자에 대한
-    @Transactional
-    public BoardResponse getBoardById(Long boardId){
-        Board board=boardRepository.findById(boardId)
-                .orElseThrow(()->new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+    @Transactional(readOnly = true)
+    public BoardResponse getBoardById(Long boardId, Long memberId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        validateSameSchool(member, board.getMember());
+
         board.increaseViewCount();
         return new BoardResponse(board);
     }
 
-    //게시글 전체 조회 - 내가 작성한
-    @Transactional(readOnly = true)
-    public List<BoardResponse> getAllMyBoards(String email) {
-
-        Member member=memberRepository.findByEmail(email).orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-
-        List<Board> boards = boardRepository.findAllByMember(member);
-
-        return boards.stream().map(BoardResponse::new).toList();
-    }
-
     //인기게시글 조회
     @Transactional
-    public List<BoardResponse> getPopularBoards(){
-        List<Board> popularBoards=boardRepository.findPopularBoards();
+    public List<BoardResponse> getPopularBoards(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        Long schoolId = member.getSchool().getId();
+        List<Board> popularBoards = boardRepository.findPopularBoardsBySchool(schoolId);
         return popularBoards.stream().map(BoardResponse::new).toList();
     }
 
 
     //게시글 검색
     @Transactional
-    public List<BoardResponse> searchBoards(String keyword){
+    public List<BoardResponse> searchBoards(String keyword, Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        Long schoolId = member.getSchool().getId();
+
         if (keyword == null || keyword.trim().isEmpty()) {
             throw new BusinessException(ErrorCode.KEYWORD_REQUIRED);
         }
 
-        List<Board> boards=boardRepository.searchByKeyword(keyword);
+        List<Board> boards=boardRepository.searchByKeyword(keyword, schoolId);
         return boards.stream().map(BoardResponse::new).toList();
     }
 
@@ -88,13 +105,19 @@ public class BoardService {
     public void deleteBoard(String email, Long boardId){
         Member member=memberRepository.findByEmail(email).orElseThrow(()-> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        Board board=boardRepository.findById(boardId).orElseThrow(()->new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+        Board board=boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
 
         if(!board.getMember().equals(member)){
             throw new BusinessException(ErrorCode.NO_PERMISSION_TO_DELETE_BOARD);
         }
 
         boardRepository.delete(board);
+    }
+
+    private void validateSameSchool(Member a, Member b) {
+        if (!a.getSchool().getId().equals(b.getSchool().getId())) {
+            throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
+        }
     }
 
 }

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -40,6 +40,8 @@ public class CommentService {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(BoardNotFoundException::new);
 
+        validateSameSchool(member, board.getMember());
+
         int nextAnonNumber = nextAnonymousNumber(board);
 
         Comment comment = Comment.builder()
@@ -72,6 +74,9 @@ public class CommentService {
                 .orElseThrow(CommentNotFoundException::new);
 
         Board board = parentComment.getBoard();
+
+        validateSameSchool(member, board.getMember());
+
         int nextAnonNumber = nextAnonymousNumber(board);
 
         Comment replycomment = Comment.builder()
@@ -105,13 +110,14 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<CommentResponseDto> getComments(Long boardId, Long memberId) {
-        if (!boardRepository.existsById(boardId)) {
-            throw new BoardNotFoundException();
-        }
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        validateSameSchool(member, board.getMember());
 
         List<Comment> topLevelComments = commentRepository.findRootsByBoardId(boardId);
-        Member member = memberId == null ? null : memberRepository.findById(memberId)
-                .orElse(null);
 
         return topLevelComments.stream()
                 .map(c -> covertToDto(c, member))
@@ -143,6 +149,8 @@ public class CommentService {
                 .orElseThrow(CommentNotFoundException::new);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
+
+        validateSameSchool(member, comment.getBoard().getMember());
 
         Optional<CommentLike> optionalLike = commentLikeRepository.findByCommentAndMember(comment, member);
 
@@ -208,6 +216,13 @@ public class CommentService {
                 replies
                 );
     }
+
+    private void validateSameSchool(Member a, Member b) {
+        if (!a.getSchool().getId().equals(b.getSchool().getId())) {
+            throw new CommentNotOwnerException();
+        }
     }
+
+}
 
 

--- a/src/main/java/backend/hiteen/common/response/ErrorCode.java
+++ b/src/main/java/backend/hiteen/common/response/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     BOARD_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 작성에 실패했습니다."),
     KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요."),
     NO_PERMISSION_TO_DELETE_BOARD(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
+    NO_PERMISSION_TO_VIEW_BOARD(HttpStatus.FORBIDDEN, "게시글 조회 권한이 없습니다."),
+    BOARD_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "게시글 접근 권한이 없습니다."),
+
 
     //comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
@@ -29,10 +32,13 @@ public enum ErrorCode {
     //love
     LOVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
     LOVE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
+    NO_PERMISSION_TO_LOVE_BOARD(HttpStatus.FORBIDDEN,"좋아요 권한이 없습니다."),
+
 
     //scrap
     SCRAP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스크랩한 게시글입니다."),
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "스크랩 정보가 존재하지 않습니다."),
+    NO_PERMISSION_TO_SCRAP_BOARD(HttpStatus.FORBIDDEN,"스크랩 권한이 없습니다."),
 
     //message
     MESSAGE_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "쪽지방을 찾을 수 없습니다."),
@@ -42,6 +48,7 @@ public enum ErrorCode {
     COMMENT_ANONYMOUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 익명번호의 댓글이 존재하지 않습니다."),
     INVALID_MESSAGE_TARGET(HttpStatus.BAD_REQUEST, "쪽지 대상은 게시글 작성자 또는 특정 댓글러 중 하나만 지정할 수 있습니다."),
     MESSAGE_ROOM_PERMISSION_DENIED(HttpStatus.FORBIDDEN,"이 쪽지방에 메시지를 보낼 권한이 없습니다."),
+    MESSAGE_PERMISSION_DENIED(HttpStatus.FORBIDDEN,"이 쪽지방에 메시지를 보낼 권한이 없습니다."),
 
 
     //Meal

--- a/src/main/java/backend/hiteen/love/exception/LoveNotOwnerException.java
+++ b/src/main/java/backend/hiteen/love/exception/LoveNotOwnerException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.love.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class LoveNotOwnerException extends BusinessException {
+    public LoveNotOwnerException() {
+        super(ErrorCode.NO_PERMISSION_TO_LOVE_BOARD);
+    }
+}

--- a/src/main/java/backend/hiteen/love/service/LoveService.java
+++ b/src/main/java/backend/hiteen/love/service/LoveService.java
@@ -1,14 +1,17 @@
 package backend.hiteen.love.service;
 
 import backend.hiteen.board.entity.Board;
+import backend.hiteen.board.exception.BoardNotFoundException;
 import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.common.response.ErrorCode;
 import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.love.dto.LoveBoardResponse;
 import backend.hiteen.love.entity.Love;
 import backend.hiteen.love.entity.LoveActionResult;
+import backend.hiteen.love.exception.LoveNotOwnerException;
 import backend.hiteen.love.repository.LoveRepository;
 import backend.hiteen.member.entity.Member;
+import backend.hiteen.member.exception.MemberNotFoundException;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,9 +32,11 @@ public class LoveService {
     public LoveActionResult updateLoveBoard(String email, Long boardId){
 
         Board board=boardRepository.findById(boardId)
-                .orElseThrow(()->new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+                .orElseThrow(BoardNotFoundException::new);
 
-        Member member=memberRepository.findByEmail(email).orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member=memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+
+        validateSameSchool(member, board.getMember());
 
         if(!isBoardLoved(member,board)){
             board.increaseLoveCount();
@@ -67,6 +72,12 @@ public class LoveService {
         Love love=loveRepository.findByMemberAndBoard(member,board)
                 .orElseThrow(()-> new BusinessException(ErrorCode.LOVE_NOT_FOUND));
         loveRepository.delete(love);
+    }
+
+    private void validateSameSchool(Member a, Member b) {
+        if (!a.getSchool().getId().equals(b.getSchool().getId())) {
+            throw new LoveNotOwnerException();
+        }
     }
 
 

--- a/src/main/java/backend/hiteen/message/exception/MessageNotOwnerException.java
+++ b/src/main/java/backend/hiteen/message/exception/MessageNotOwnerException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.message.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class MessageNotOwnerException extends BusinessException {
+    public MessageNotOwnerException() {
+        super(ErrorCode.MESSAGE_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/backend/hiteen/message/service/MessageService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageService.java
@@ -7,7 +7,12 @@ import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.comment.entity.Comment;
 import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.common.response.ApiResponse;
+import backend.hiteen.common.response.ErrorCode;
 import backend.hiteen.common.response.SuccessCode;
+import backend.hiteen.global.exception.BusinessException;
+import backend.hiteen.member.entity.Member;
+import backend.hiteen.member.exception.MemberNotFoundException;
+import backend.hiteen.member.repository.MemberRepository;
 import backend.hiteen.message.dto.request.MessageRequest;
 import backend.hiteen.message.dto.response.MessageResponse;
 import backend.hiteen.message.dto.response.MessageRoomListResponse;
@@ -33,6 +38,7 @@ public class MessageService {
     private final MessageRepository messageRepository;
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
     private final MessageRoomRepository messageRoomRepository;
     private final MessageAsyncService messageAsyncService;
 
@@ -67,6 +73,15 @@ public class MessageService {
         }
         else {
             throw new MessageTargetNotSpecifiedException();
+        }
+
+        Member sender = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        if (!sender.getSchool().getId().equals(receiver.getSchool().getId())) {
+            throw new BusinessException(ErrorCode.MESSAGE_PERMISSION_DENIED);
         }
 
         MessageRoom room = messageRoomRepository

--- a/src/main/java/backend/hiteen/scrap/exception/ScrapNotFoundException.java
+++ b/src/main/java/backend/hiteen/scrap/exception/ScrapNotFoundException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.scrap.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class ScrapNotFoundException extends BusinessException {
+    public ScrapNotFoundException() {
+        super(ErrorCode.SCRAP_NOT_FOUND);
+    }
+}

--- a/src/main/java/backend/hiteen/scrap/exception/ScrapNotOwnerException.java
+++ b/src/main/java/backend/hiteen/scrap/exception/ScrapNotOwnerException.java
@@ -1,0 +1,10 @@
+package backend.hiteen.scrap.exception;
+
+import backend.hiteen.common.response.ErrorCode;
+import backend.hiteen.global.exception.BusinessException;
+
+public class ScrapNotOwnerException extends BusinessException {
+    public ScrapNotOwnerException() {
+        super(ErrorCode.NO_PERMISSION_TO_SCRAP_BOARD);
+    }
+}

--- a/src/main/java/backend/hiteen/scrap/service/ScrapService.java
+++ b/src/main/java/backend/hiteen/scrap/service/ScrapService.java
@@ -1,14 +1,18 @@
 package backend.hiteen.scrap.service;
 
 import backend.hiteen.board.entity.Board;
+import backend.hiteen.board.exception.BoardNotFoundException;
 import backend.hiteen.board.repository.BoardRepository;
 import backend.hiteen.common.response.ErrorCode;
 import backend.hiteen.global.exception.BusinessException;
 import backend.hiteen.member.entity.Member;
+import backend.hiteen.member.exception.MemberNotFoundException;
 import backend.hiteen.member.repository.MemberRepository;
 import backend.hiteen.scrap.dto.ScrapBoardResponse;
 import backend.hiteen.scrap.entity.Scrap;
 import backend.hiteen.scrap.entity.ScrapActionResult;
+import backend.hiteen.scrap.exception.ScrapNotFoundException;
+import backend.hiteen.scrap.exception.ScrapNotOwnerException;
 import backend.hiteen.scrap.repository.ScrapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,10 +32,12 @@ public class ScrapService {
     @Transactional
     public ScrapActionResult updateScrapBoard(String email, Long boardId){
         Member member=memberRepository.findByEmail(email)
-                .orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(MemberNotFoundException::new);
 
         Board board=boardRepository.findById(boardId)
-                .orElseThrow(()-> new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+                .orElseThrow(BoardNotFoundException::new);
+
+        validateSameSchool(member, board.getMember());
 
         if (!isBoardScrapped(member, board)){
             board.increaseScrapCount();
@@ -48,7 +54,7 @@ public class ScrapService {
     public List<ScrapBoardResponse> getMyScrapedBoards(String email){
 
         Member member=memberRepository.findByEmail(email)
-                .orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(MemberNotFoundException::new);
 
         List<Board> boards=scrapRepository.findScrapedBoardsByMemberId(member.getId());
 
@@ -66,7 +72,15 @@ public class ScrapService {
 
     private void deleteScrap(Member member, Board board){
         Scrap scrap=scrapRepository.findByMemberAndBoard(member, board)
-                .orElseThrow(()-> new BusinessException(ErrorCode.SCRAP_NOT_FOUND));
+                .orElseThrow(ScrapNotFoundException::new);
         scrapRepository.delete(scrap);
     }
+
+
+    private void validateSameSchool(Member a, Member b) {
+        if (!a.getSchool().getId().equals(b.getSchool().getId())) {
+            throw new ScrapNotOwnerException();
+        }
+    }
+
 }


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
도메인 별 조회 시 해당 학교 권한만 볼 수 있도록 서비스 로직과 쿼리를 수정하여 타 학교 게시글이 노출되지 않도록 개선

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 학교별로만 볼 수 있도록 Service/Repository 쿼리 수정
- 작업 2 내가 쓴 글 조회 시 내 학교에서 작성한 글만 조회하도록 분리

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1
- 공유 사항 2
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
cloased #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board, comment, like, scrap, and message actions are now restricted to users within the same school, enhancing access control and privacy.
  * Error messages for permission issues on boards, likes, scraps, and messages are now more specific and user-friendly.

* **Improvements**
  * Board-related endpoints and searches now return results scoped to the user's school.
  * Endpoint for retrieving a user's own boards changed from `/my` to `/me`.

* **Bug Fixes**
  * Improved validation to prevent unauthorized access across different schools.

* **Chores**
  * Removed unused imports and obsolete exception classes for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->