### PR TITLE
[Feat] 댓글 카운트 구현

### DIFF
--- a/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
+++ b/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
@@ -17,6 +17,7 @@ public class BoardResponse {
     private final String categoryLabel;
     private final int loveCount;
     private final int scrapCount;
+    private final int commentCount;
     private final Long viewCount;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
@@ -31,6 +32,7 @@ public class BoardResponse {
         this.content=board.getContent();
         this.loveCount=board.getLoveCount();
         this.scrapCount= board.getScrapCount();
+        this.commentCount=board.getCommentCount();
         this.createdAt = board.getCreatedAt();
         this.viewCount=board.getViewCount();
     }

--- a/src/main/java/backend/hiteen/board/entity/Board.java
+++ b/src/main/java/backend/hiteen/board/entity/Board.java
@@ -42,6 +42,9 @@ public class Board extends BaseTimeEntity {
     @Column
     private int scrapCount;
 
+    @Column
+    private Integer commentCount;
+
     @Column(nullable = false)
     private Long viewCount = 0L;
 
@@ -62,6 +65,7 @@ public class Board extends BaseTimeEntity {
         this.content = content;
         this.loveCount = 0;
         this.scrapCount = 0;
+        this.commentCount = 0;
         this.disclosureStatus = disclosureStatus;
         this.category = category;
     }
@@ -94,6 +98,22 @@ public class Board extends BaseTimeEntity {
 
     public void decreaseScrapCount() {
         this.scrapCount -= 1;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount = (this.commentCount == null ? 0 : this.commentCount) + 1;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount = (this.commentCount == null ? 1 : this.commentCount) - 1;
+    }
+
+    public void setCommentCount(int commentCount) {
+        this.commentCount = commentCount;
+    }
+
+    public int getCommentCount() {
+        return this.commentCount == null ? 0 : this.commentCount;
     }
 
     public void increaseViewCount() {

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -3,13 +3,17 @@ package backend.hiteen.board.service;
 import backend.hiteen.board.dto.request.BoardCreateRequest;
 import backend.hiteen.board.dto.response.BoardResponse;
 import backend.hiteen.board.entity.Board;
-import backend.hiteen.board.exception.*;
 import backend.hiteen.board.exception.BoardNotFoundException;
+import backend.hiteen.board.exception.BoardNotOwnerException;
+import backend.hiteen.board.exception.KeywordRequiredException;
+import backend.hiteen.board.exception.NoPermissionToDeleteBoardException;
 import backend.hiteen.board.repository.BoardRepository;
+import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.exception.MemberNotFoundException;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +21,11 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class BoardService {
+public class BoardService implements CommandLineRunner {
 
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
 
     // 게시글 작성
     @Transactional
@@ -117,6 +122,27 @@ public class BoardService {
         if (!a.getSchool().getId().equals(b.getSchool().getId())) {
             throw new BoardNotOwnerException();
         }
+    }
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        initializeCommentCounts();
+    }
+
+    private void initializeCommentCounts() {
+        List<Board> boards = boardRepository.findAll();
+
+        for (Board board : boards) {
+            int actualCommentCount = commentRepository.countByBoardId(board.getId());
+            int currentCommentCount = board.getCommentCount();
+
+            // 실제 댓글 수와 현재 카운트가 다르면 업데이트
+            if (actualCommentCount != currentCommentCount) {
+                board.setCommentCount(actualCommentCount);
+            }
+        }
+        boardRepository.saveAll(boards);
     }
 
 }

--- a/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
+++ b/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
@@ -19,6 +19,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.board.id = :boardId AND c.parentComment IS NULL ORDER BY c.createdAt ASC")
     List<Comment> findRootsByBoardId(@Param("boardId") Long boardId);
 
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.board.id = :boardId")
+    int countByBoardId(@Param("boardId") Long boardId);
+
     Optional<Comment> findByBoardIdAndMemberId(Long boardId, Long memberId);
 
     List<Comment> findAllByMember(Member member);

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -51,6 +51,9 @@ public class CommentService {
                 .anonymousNumber(nextAnonNumber)
                 .build();
         commentRepository.save(comment);
+        
+        // 댓글 카운트 증가
+        board.increaseCommentCount();
 
         boolean isBoardWriter = comment.getMember().getId().equals(board.getMember().getId());
 
@@ -88,6 +91,9 @@ public class CommentService {
                 .build();
 
         commentRepository.save(replycomment);
+        
+        // 댓글 카운트 증가 (대댓글도 포함)
+        board.increaseCommentCount();
 
         boolean replyIsBoardWriter = replycomment.getMember().getId().equals(board.getMember().getId());
 
@@ -177,6 +183,16 @@ public class CommentService {
 
         if (!comment.getMember().getId().equals(memberId)) {
             throw new CommentNotOwnerException();
+        }
+        
+        Board board = comment.getBoard();
+        
+        // 삭제될 댓글 수 계산 (본 댓글 + 모든 대댓글)
+        int deletedCommentsCount = 1 + comment.getChildrenComment().size();
+        
+        // 댓글 삭제 시 카운트 감소
+        for (int i = 0; i < deletedCommentsCount; i++) {
+            board.decreaseCommentCount();
         }
 
         commentRepository.delete(comment);


### PR DESCRIPTION
## 📑 PR 요약
게시글에 댓글 카운트 기능을 추가

## ☑ 작업 내용
- Board 엔티티에 `commentCount` 필드 및 관련 메서드 추가
- 댓글 생성/삭제 시 게시글의 댓글 카운트 자동 업데이트 
- BoardResponse DTO에 댓글 카운트 필드 추가
- CommentRepository에 게시글별 댓글 수 조회 메서드 추가

## 📣 공유사항
- 애플리케이션 시작 시 기존 게시글들의 댓글 카운트가 자동으로 초기화됨
- 댓글/대댓글 추가 시 자동으로 카운트가 증가하고 삭제 시 감소
- 대댓글 삭제 시에도 orphanRemoval로 인한 연쇄 삭제를 고려하여 정확한 카운트를 유지

## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boards now display the total number of comments.
  * API responses include a commentCount field for each board.

* **Bug Fixes**
  * Comment counts update immediately when adding or deleting comments and replies.
  * Deleting a comment adjusts the count to include its direct replies.
  * Counts are synchronized at startup to correct any mismatches between stored counts and actual comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->