### PR TITLE
fix : 조회 수 반영 안 되는 문제 해결

### DIFF
--- a/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
+++ b/src/main/java/backend/hiteen/board/dto/response/BoardResponse.java
@@ -18,7 +18,7 @@ public class BoardResponse {
     private final int loveCount;
     private final int scrapCount;
     private final int commentCount;
-    private final Long viewCount;
+    private final int viewCount;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;

--- a/src/main/java/backend/hiteen/board/entity/Board.java
+++ b/src/main/java/backend/hiteen/board/entity/Board.java
@@ -46,7 +46,7 @@ public class Board extends BaseTimeEntity {
     private Integer commentCount;
 
     @Column(nullable = false)
-    private Long viewCount = 0L;
+    private int viewCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/backend/hiteen/board/service/BoardService.java
+++ b/src/main/java/backend/hiteen/board/service/BoardService.java
@@ -66,7 +66,7 @@ public class BoardService implements CommandLineRunner {
 
 
     //게시글 단일 조회 - 모든 사용자에 대한
-    @Transactional(readOnly = true)
+    @Transactional
     public BoardResponse getBoardById(Long boardId, Long memberId) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(BoardNotFoundException::new);


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
게시글 단일 조회 시 조회수가 증가하지 않는 문제 수정

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 작업 1 BoardService.getBoardById 메서드에서 @Transactional(readOnly = true) 제거
- 작업 2

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 공유 사항 1 현재는 단순히 readOnly 속성만 제거했으나 트래픽이 많아질 경우 원자적 증가 쿼리로 개선할 필요가 있습니다.
- 공유 사항 2 추후 동시성 이슈가 우려되면 JPQL update 방식으로 변경 고려 부탁드립니다.
 
## 🔗 관련 이슈
<!-- 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - View counts on posts now increment and display correctly after being viewed.
  - Resolves cases where counts could appear stuck or show unexpected values.

- Performance & Reliability
  - Improved consistency of view count tracking across the app.
  - Reduces chances of missing or null view counts and ensures updates are reflected reliably after refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->