### PR TITLE
fix : 댓글 작성 API 부하테스트 중 발생한 데드락(Deadlock) 동시성 이슈 해결

### DIFF
--- a/src/main/java/backend/hiteen/board/repository/BoardRepository.java
+++ b/src/main/java/backend/hiteen/board/repository/BoardRepository.java
@@ -2,11 +2,14 @@ package backend.hiteen.board.repository;
 
 import backend.hiteen.board.entity.Board;
 import backend.hiteen.member.entity.Member;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board,Long> {
     List<Board> findAllByMember_School_Id(Long schoolId);
@@ -27,5 +30,10 @@ public interface BoardRepository extends JpaRepository<Board,Long> {
     ORDER BY board.createdAt DESC
 """)
     List<Board> searchByKeyword(@Param("keyword") String keyword, @Param("schoolId") Long schoolId);
+
+    // 비관적 락(Pessimistic Lock) 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM Board b WHERE b.id = :boardId")
+    Optional<Board> findByIdWithPessimisticLock(@Param("boardId") Long boardId);
 
 }

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -37,7 +37,7 @@ public class CommentService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
-        Board board = boardRepository.findById(boardId)
+        Board board = boardRepository.findByIdWithPessimisticLock(boardId)
                 .orElseThrow(BoardNotFoundException::new);
 
         validateSameSchool(member, board.getMember());


### PR DESCRIPTION
## 📑 PR 요약
댓글 작성 API 부하테스트 중 발생한 데드락(Deadlock) 동시성 이슈 해결

## ☑ 작업 내용
- `BoardRepository`에 비관적 락(Pessimistic Lock)을 적용한 `findByIdWithPessimisticLock` 조회 메서드 추가
- `CommentService`의 댓글 작성 로직(`addComment`)에서 게시글 조회 시 비관적 락을 사용하도록 변경하여, `comment_count` 업데이트 시 다중 스레드 환경에서 발생하는 데드락(Deadlock) 원천 차단

## 📣 공유사항
- nGrinder 부하테스트(Vuser 10명 기준) 결과, 기존 에러율 약 30.4% -> 4.5%로 감소 및 데드락(HTTP 500) 완벽 해결, 확인 완료.
- CPU 사용량 또한 60%-> 25%대로 안정화됨.
- 이후 Vuser 100명 규모의 추가 부하테스트를 진행하여 한계점을 측정할 예정.
 
## 🔗 관련 이슈
closed #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved data consistency when multiple users add comments to boards simultaneously, preventing potential race conditions and ensuring reliable concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->