### PR TITLE
[perf] 댓글 조회 시 페이지네이션을 적용 및 N+1 문제를 @BatchSize 적용.

### DIFF
--- a/src/main/java/backend/hiteen/comment/controller/CommentController.java
+++ b/src/main/java/backend/hiteen/comment/controller/CommentController.java
@@ -13,6 +13,9 @@ import backend.hiteen.common.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -62,11 +65,12 @@ public class CommentController {
 
     @GetMapping("/board/{boardId}")
     @Operation(summary = "댓글 조회", description = "게시글에 달린 댓글과 대댓글을 모두 조회합니다.")
-    public ResponseEntity<ApiResponse<List<CommentResponseDto>>> getComments(
+    public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> getComments(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @PathVariable Long boardId) {
+            @PathVariable Long boardId,
+            @ParameterObject Pageable pageable) {
         Long memberId = principal != null ? principal.getId() : null;
-        List<CommentResponseDto> comments = commentService.getComments(boardId, memberId);
+        Page<CommentResponseDto> comments = commentService.getComments(boardId, memberId, pageable);
 
         return ResponseEntity
                 .status(SuccessCode.COMMENT_FETCHED.getStatus())

--- a/src/main/java/backend/hiteen/comment/entity/Comment.java
+++ b/src/main/java/backend/hiteen/comment/entity/Comment.java
@@ -5,6 +5,7 @@ import backend.hiteen.global.entity.BaseTimeEntity;
 import backend.hiteen.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,7 @@ public class Comment extends BaseTimeEntity {
 
     // 대댓글
     @Builder.Default
+    @BatchSize(size=100)
     @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
     private List<Comment> childrenComment = new ArrayList<>();
 

--- a/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
+++ b/src/main/java/backend/hiteen/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package backend.hiteen.comment.repository;
 
 import backend.hiteen.comment.entity.Comment;
 import backend.hiteen.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +19,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Integer findMaxAnonymousNumberByBoardId(@Param("boardId") Long boardId);
 
     @Query("SELECT c FROM Comment c WHERE c.board.id = :boardId AND c.parentComment IS NULL ORDER BY c.createdAt ASC")
-    List<Comment> findRootsByBoardId(@Param("boardId") Long boardId);
+    Page<Comment> findRootsByBoardId(@Param("boardId") Long boardId, Pageable pageable);
 
     @Query("SELECT COUNT(c) FROM Comment c WHERE c.board.id = :boardId")
     int countByBoardId(@Param("boardId") Long boardId);
@@ -27,6 +29,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByMember(Member member);
 
     Optional<Comment> findByBoardIdAndAnonymousNumber(Long boardId, Integer anonymousNumber);
-
 
 }

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -16,6 +16,8 @@ import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.exception.member.MemberNotFoundException;
 import backend.hiteen.member.repository.MemberRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -115,7 +117,7 @@ public class CommentService {
 
 
     @Transactional(readOnly = true)
-    public List<CommentResponseDto> getComments(Long boardId, Long memberId) {
+    public Page<CommentResponseDto> getComments(Long boardId, Long memberId, Pageable pageable) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(BoardNotFoundException::new);
         Member member = memberRepository.findById(memberId)
@@ -123,11 +125,10 @@ public class CommentService {
 
         validateSameSchool(member, board.getMember());
 
-        List<Comment> topLevelComments = commentRepository.findRootsByBoardId(boardId);
+        Page<Comment> topLevelComments = commentRepository.findRootsByBoardId(boardId, pageable);
 
-        return topLevelComments.stream()
-                .map(c -> covertToDto(c, member))
-                .toList();
+        return topLevelComments
+                .map(c -> covertToDto(c, member));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📑 PR 요약
댓글 조회 시 페이지네이션을 적용하고, 발생하던 N+1 문제를 @BatchSize 적용으로 해결.

## ☑ 작업 내용
- 댓글 조회 API에 `Pageable` 적용으로 페이지네이션 구현
- `CommentRepository`에 `findRootsByBoardId` 메서드를 `Page<Comment>` 반환으로 변경
- `Comment` 엔티티의 `childrenComment` 컬렉션에 `@BatchSize(size = 100)` 추가

## 📣 공유사항
- nGrinder 부하테스트 결과 (Vuser 99명 기준)
  - TPS: 16.5 → 284.0 (약 17배 향상)
  - 에러율: 46% → 0%
- 페이지네이션과 fetch join 동시 사용 시 메모리 페이지네이션 문제가 발생하므로 @BatchSize 방식 채택

## 🔗 관련 이슈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment retrieval now supports pagination, allowing efficient loading of comments in pages instead of all at once.

* **Performance Improvements**
  * Enhanced comment loading with batch fetching optimization for nested reply structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->