### PR TITLE
feat : redis 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.3.17'
 	implementation 'com.mysql:mysql-connector-j:8.3.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
@@ -37,6 +37,9 @@ dependencies {
 
 	//외부 api 연동
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	//모니터링
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -16,6 +16,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:7.0
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - app_network
 
   backend:
     build:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -7,9 +7,14 @@ spring:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
 management:
   endpoints:
     web:
       exposure:
         include: 'health,info,prometheus'
-

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,3 +7,8 @@ spring:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}


### PR DESCRIPTION
## 📑 PR 요약
Redis 환경 설정을 추가

## ☑ 작업 내용
- Docker Compose에 Redis 컨테이너 추가
- build.gradle에 spring-boot-starter-data-redis 의존성 추가
- application-local.yml, application-docker.yml에 Redis 연결 설정 추가
- local.env, backend.env에 REDIS_HOST, REDIS_PORT 환경변수 추가

## 📣 공유사항
- 추후 댓글 조회 캐싱, 세션 관리 등에 활용 예정

## 🔗 관련 이슈
closed #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Redis as a new service component.

* **Chores**
  * Updated OpenAPI dependency from version 2.7.0 to 3.3.17.
  * Added Redis containerized service to development environment with port 6379 exposed.
  * Configured Redis connection settings for local development and Docker deployment profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->