### PR TITLE
perf: Redis 캐싱 적용으로 댓글 조회 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.3.17'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'com.mysql:mysql-connector-j:8.3.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/backend/hiteen/HiteenApplication.java
+++ b/src/main/java/backend/hiteen/HiteenApplication.java
@@ -2,12 +2,14 @@ package backend.hiteen;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableAsync
+@EnableCaching
 public class HiteenApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/backend/hiteen/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/backend/hiteen/comment/dto/response/CommentResponseDto.java
@@ -3,13 +3,16 @@ package backend.hiteen.comment.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
-public class CommentResponseDto {
+public class CommentResponseDto implements Serializable {
 
     @Schema(description = "댓글 id")
     private Long commentId;

--- a/src/main/java/backend/hiteen/comment/dto/response/ReplyCommentResponseDto.java
+++ b/src/main/java/backend/hiteen/comment/dto/response/ReplyCommentResponseDto.java
@@ -3,12 +3,15 @@ package backend.hiteen.comment.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
-public class ReplyCommentResponseDto {
+public class ReplyCommentResponseDto implements Serializable {
 
     @Schema(description = "대댓글 id")
     private Long replyId;

--- a/src/main/java/backend/hiteen/comment/service/CommentService.java
+++ b/src/main/java/backend/hiteen/comment/service/CommentService.java
@@ -15,7 +15,10 @@ import backend.hiteen.comment.repository.CommentRepository;
 import backend.hiteen.member.entity.Member;
 import backend.hiteen.member.exception.member.MemberNotFoundException;
 import backend.hiteen.member.repository.MemberRepository;
+import backend.hiteen.global.util.RestPage;
 import lombok.AllArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -35,6 +38,7 @@ public class CommentService {
 
     // 댓글 등록
     @Transactional
+    @CacheEvict(value = "comments", allEntries = true)
     public CommentResponseDto addComment(Long memberId, Long boardId, String content) {
 
         Member member = memberRepository.findById(memberId)
@@ -72,6 +76,7 @@ public class CommentService {
     }
 
     @Transactional
+    @CacheEvict(value = "comments", allEntries = true)
     public ReplyCommentResponseDto addReplyComment(Long memberId,Long parentCommentId, String content) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
@@ -117,7 +122,8 @@ public class CommentService {
 
 
     @Transactional(readOnly = true)
-    public Page<CommentResponseDto> getComments(Long boardId, Long memberId, Pageable pageable) {
+    @Cacheable(value = "comments", key = "#boardId + '_' + #memberId + '_' + #pageable.pageNumber + '_' + #pageable.pageSize")
+    public RestPage<CommentResponseDto> getComments(Long boardId, Long memberId, Pageable pageable) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(BoardNotFoundException::new);
         Member member = memberRepository.findById(memberId)
@@ -127,8 +133,7 @@ public class CommentService {
 
         Page<Comment> topLevelComments = commentRepository.findRootsByBoardId(boardId, pageable);
 
-        return topLevelComments
-                .map(c -> covertToDto(c, member));
+        return new RestPage<>(topLevelComments.map(c -> covertToDto(c, member)));
     }
 
     @Transactional(readOnly = true)
@@ -151,6 +156,7 @@ public class CommentService {
     }
 
     @Transactional
+    @CacheEvict(value = "comments", allEntries = true)
     public CommentLikeResponse toggleLike(Long commentId, Long memberId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);
@@ -178,6 +184,7 @@ public class CommentService {
     }
 
     @Transactional
+    @CacheEvict(value = "comments", allEntries = true)
     public void deleteComment(Long memberId, Long commentId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);

--- a/src/main/java/backend/hiteen/global/config/RedisConfig.java
+++ b/src/main/java/backend/hiteen/global/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package backend.hiteen.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/java/backend/hiteen/global/util/RestPage.java
+++ b/src/main/java/backend/hiteen/global/util/RestPage.java
@@ -1,0 +1,22 @@
+package backend.hiteen.global.util;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+
+public class RestPage<T> extends PageImpl<T> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+
+    public RestPage(List<T> content) {
+        super(content);
+    }
+}


### PR DESCRIPTION
## 📑 PR 요약
Redis 캐싱을 적용하여 댓글 조회 성능을 개선

## ☑ 작업 내용
- `RedisConfig` 추가 (TTL 10분, JDK 직렬화)
- `HiteenApplication`에 `@EnableCaching` 추가
- `CommentService` 댓글 조회에 `@Cacheable` 적용 (캐시 키: boardId_memberId_page_size)
- 댓글 작성/삭제/좋아요 시 `@CacheEvict(allEntries = true)` 적용
- `RestPage` 래퍼 클래스 추가 (Page 직렬화)
- `CommentResponseDto`, `ReplyCommentResponseDto` Serializable 구현

## 📣 공유사항
- nGrinder 부하테스트 결과 (Vuser 99명 기준)

| 단계 | TPS | 에러율 |
|---|---|---|
| 최초 (N+1) | 16.5 | 46% |
| 페이지네이션 + @BatchSize | 284 | 0% |
| Redis 캐싱 추가 | 969 | 12%* |

*12% 에러는 로컬 DB 커넥션 한계로 인한 것
- `Page` 직렬화 이슈로 `RestPage` 래퍼 클래스를 별도 구현하여 해결

## 🔗 관련 이슈
closed #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented caching for comment data with automatic invalidation on updates, additions, deletions, and likes.
  * Added Redis-based cache configuration with 10-minute expiration.

* **Refactor**
  * Enhanced serialization support for comment response objects.
  * Updated response structure for paginated comment results.

* **Chores**
  * Updated springdoc-openapi dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->