### PR TITLE
perf: 쪽지방 목록 조회 N+1 문제 해결

### DIFF
--- a/src/main/java/backend/hiteen/message/repository/MessageRepository.java
+++ b/src/main/java/backend/hiteen/message/repository/MessageRepository.java
@@ -19,6 +19,16 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     int countByMessageRoomIdAndReceiverIdAndIsReadFalse(Long roomId, Long memberId);
 
+    @Query("SELECT m FROM Message m WHERE m.id IN (" +
+            "SELECT MAX(m2.id) FROM Message m2 WHERE m2.messageRoom.id IN :roomIds GROUP BY m2.messageRoom.id)")
+    List<Message> findLastMessagesByRoomIds(@Param("roomIds") List<Long> roomIds);
+
+    @Query("SELECT m.messageRoom.id, COUNT(m) FROM Message m " +
+            "WHERE m.messageRoom.id IN :roomIds " +
+            "AND m.receiverId = :memberId AND m.isRead = false " +
+            "GROUP BY m.messageRoom.id")
+    List<Object[]> countUnreadByRoomIds(@Param("roomIds") List<Long> roomIds, @Param("memberId") Long memberId);
+
     @Modifying
     @Query("UPDATE Message m " +
             "SET m.isRead = true " +

--- a/src/main/java/backend/hiteen/message/service/MessageService.java
+++ b/src/main/java/backend/hiteen/message/service/MessageService.java
@@ -31,6 +31,8 @@ import org.springframework.web.context.request.async.DeferredResult;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -146,12 +148,26 @@ public class MessageService {
 
     public List<MessageRoomListResponse> getMyMessageRooms(Long memberId) {
         List<MessageRoom> rooms = messageRoomRepository.findAllByMemberOrderByUpdatedAtDesc(memberId);
+        if (rooms.isEmpty()) return List.of();
+
+        List<Long> roomIds = rooms.stream().map(MessageRoom::getId).toList();
+
+        // 마지막 메시지 한 번에 조회
+        Map<Long, Message> lastMessageMap = messageRepository.findLastMessagesByRoomIds(roomIds)
+                .stream()
+                .collect(Collectors.toMap(m -> m.getMessageRoom().getId(), m -> m));
+
+        // 읽지 않은 메시지 수 한 번에 조회
+        Map<Long, Long> unreadCountMap = messageRepository.countUnreadByRoomIds(roomIds, memberId)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
 
         List<MessageRoomListResponse> result = new ArrayList<>();
         for (MessageRoom room : rooms) {
-            Message lastMsg = messageRepository
-                    .findTopByMessageRoomIdOrderByCreatedAtDesc(room.getId())
-                    .orElse(null);
+            Message lastMsg = lastMessageMap.get(room.getId());
 
             String lastMessage = lastMsg != null ? lastMsg.getContent() : null;
             LocalDateTime lastMessageTime = lastMsg != null ? lastMsg.getCreatedAt() : null;
@@ -160,7 +176,7 @@ public class MessageService {
             Long targetId = room.getSenderId().equals(memberId) ? room.getReceiverId() : room.getSenderId();
             String targetNickname = MessageMapper.computeDisplayName(room, targetId);
 
-            int unreadCount = messageRepository.countByMessageRoomIdAndReceiverIdAndIsReadFalse(room.getId(), memberId);
+            int unreadCount = unreadCountMap.getOrDefault(room.getId(), 0L).intValue();
 
             result.add(new MessageRoomListResponse(
                     room.getId(),


### PR DESCRIPTION
## 📑 PR 요약
쪽지방 목록 조회 시 발생하던 N+1 문제를 해결

## ☑ 작업 내용
- `MessageRepository`에 방 ID 목록으로 마지막 메시지를 한 번에 조회하는 쿼리 추가
- `MessageRepository`에 방 ID 목록으로 읽지 않은 메시지 수를 한 번에 조회하는 쿼리 추가
- `MessageService`에서 루프 안 개별 쿼리 → IN절 일괄 조회로 변경

## 📣 공유사항
- 쿼리 수 개선 (쪽지방 10개 기준)
  - Before: 21개 (1 + N + N)
  - After: 3개 (1 + 1 + 1)
- 방 개수가 늘어날수록 개선 효과가 커지는 구조

## 🔗 관련 이슈
closed #121 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized message room loading by consolidating multiple database queries into efficient bulk operations, reducing individual database calls and improving response times when retrieving message lists and unread message counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->