### PR TITLE
perf: 급식/시간표 외부 API 반복 호출 Redis 캐싱으로 성능 개선

### DIFF
--- a/src/main/java/backend/hiteen/externalapi/meal/dto/MealDto.java
+++ b/src/main/java/backend/hiteen/externalapi/meal/dto/MealDto.java
@@ -2,10 +2,11 @@ package backend.hiteen.externalapi.meal.dto;
 
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
-public class MealDto {
+public class MealDto implements Serializable {
     private final List<String> menus;
     private final String calories;
     private final String nutrients;

--- a/src/main/java/backend/hiteen/externalapi/meal/service/MealService.java
+++ b/src/main/java/backend/hiteen/externalapi/meal/service/MealService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -25,6 +26,7 @@ public class MealService {
     @Value("${openapi.api-key}")
     private String apiKey;
 
+    @Cacheable(value = "meal", key = "#officeCode + '_' + #schoolCode + '_' + #year + '_' + #month")
     public Map<String, Map<String, MealDto>> getSchoolMeal(String officeCode, String schoolCode, int year, int month)
     {
 

--- a/src/main/java/backend/hiteen/externalapi/timetable/dto/TimeTableDto.java
+++ b/src/main/java/backend/hiteen/externalapi/timetable/dto/TimeTableDto.java
@@ -5,10 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class TimeTableDto {
+public class TimeTableDto implements Serializable {
 
     @Schema(description = "교시 번호(1교시, 2교시....)", example = "1")
     private int period;

--- a/src/main/java/backend/hiteen/externalapi/timetable/service/TimeTableService.java
+++ b/src/main/java/backend/hiteen/externalapi/timetable/service/TimeTableService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -29,6 +30,7 @@ public class TimeTableService {
     @Value("${openapi.api-key}")
     private String apiKey;
 
+    @Cacheable(value = "timetable", key = "#officeCode + '_' + #schoolCode + '_' + #grade + '_' + #classNum + '_' + T(java.time.LocalDate).now().with(T(java.time.DayOfWeek).MONDAY)")
     public Map<String, List<TimeTableDto>> getTimeTable(
             String officeCode,
             String schoolCode,

--- a/src/main/java/backend/hiteen/global/config/RedisConfig.java
+++ b/src/main/java/backend/hiteen/global/config/RedisConfig.java
@@ -9,18 +9,25 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.util.Map;
 
 @Configuration
 public class RedisConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10))
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
 
+        Map<String, RedisCacheConfiguration> cacheConfigurations = Map.of(
+                "comments", defaultConfig.entryTtl(Duration.ofMinutes(10)),
+                "meal", defaultConfig.entryTtl(Duration.ofDays(1)),
+                "timetable", defaultConfig.entryTtl(Duration.ofDays(7))
+        );
+
         return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(config)
+                .cacheDefaults(defaultConfig.entryTtl(Duration.ofMinutes(10)))
+                .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
     }
 }


### PR DESCRIPTION
## 📑 PR 요약
Redis 캐싱을 적용하여 급식/시간표 외부 API 반복 호출 성능 개선

## ☑ 작업 내용
- `RedisConfig` 캐시별 TTL 분리 설정 (meal: 1일, timetable: 7일)
- `MealService` 급식 조회에 `@Cacheable` 적용 (캐시 키: officeCode_schoolCode_year_month)
- `TimeTableService` 시간표 조회에 `@Cacheable` 적용 (캐시 키: officeCode_schoolCode_grade_classNum_이번주월요일)
- `MealDto`, `TimeTableDto` Serializable 구현

## 📣 공유사항
| 단계 | 응답시간 |
|---|---|
| 캐싱 전 (NEIS 외부 API 직접 호출) | 359ms |
| 캐싱 후 (Redis 캐시 히트) | 14ms |

약 25배 응답속도 개선
- 시간표는 이번 주 월요일 날짜를 캐시 키에 포함하여 주가 바뀌면 자동으로 새 데이터 조회

## 🔗 관련 이슈
closed #123